### PR TITLE
Add ruby-loco mingw and mswin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,24 +9,18 @@ on:
     paths-ignore:
     - README.md
 jobs:
-  test:
+  common:
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest ]
         # Use various version syntaxes here for testing
-        ruby: [ .ruby-version, .tool-versions, 2.2, 2.3, ruby-head, jruby, jruby-head, truffleruby, truffleruby-head, rubinius ]
+        ruby: [ .ruby-version, .tool-versions, 2.2, 2.3, ruby-head, jruby, jruby-head, truffleruby, truffleruby-head ]
         exclude:
         - os: windows-latest
           ruby: truffleruby
         - os: windows-latest
           ruby: truffleruby-head
-        - os: ubuntu-16.04
-          ruby: rubinius
-        - os: macos-latest
-          ruby: rubinius
-        - os: windows-latest
-          ruby: rubinius
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,9 +28,20 @@ jobs:
     - uses: ./
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: ruby --version
-    - run: ridk version
-      if: matrix.os == 'windows-latest' && !startsWith(matrix.ruby, 'jruby') && !startsWith(matrix.ruby, '2.3') && !startsWith(matrix.ruby, '2.2')
+    - name: ruby version and gcc
+      run: |
+        ruby --version
+        ruby -e "puts 'build gcc: ' + RbConfig::CONFIG.fetch('CC_VERSION_MESSAGE', 'unknown')[/[^\n]+/]"      
+    - name: ridk version (mingw)
+      if: matrix.os == 'windows-latest'
+      run: |
+        # run 'ridk version'
+        $abi, $plat = $(ruby -e "STDOUT.write RbConfig::CONFIG['ruby_version'] + ' ' + RUBY_PLATFORM").split(' ')
+        if (($abi -ge '2.4') -and $plat.Contains('mingw')) {
+          ridk version
+        } else {
+          echo 'ridk is unavailable'
+        }
     - name: Subprocess test
       run: ruby test_subprocess.rb
     - name: OpenSSL version
@@ -45,6 +50,62 @@ jobs:
       run: ruby -ropen-uri -e 'puts open(%{https://rubygems.org/}) { |f| f.read(1024) }'
     - name: C extension test
       run: gem install json:2.2.0 --no-document
+    - run: bundle --version
+    - run: bundle install
+    - run: bundle exec rake --version
+
+  specials:
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { ruby: rubinius, os: ubuntu-18.04   }
+          - { ruby: mingw   , os: windows-latest }
+          - { ruby: mswin   , os: windows-latest }
+    name: ${{ matrix.cfg.os }} ${{ matrix.cfg.ruby }}
+    runs-on: ${{ matrix.cfg.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        ruby-version: ${{ matrix.cfg.ruby }}
+    - name: ruby version and gcc
+      run: |
+        ruby --version
+        ruby -e "puts 'build gcc: ' + RbConfig::CONFIG.fetch('CC_VERSION_MESSAGE', 'unknown')[/[^\n]+/]"      
+    - name: ridk version (mingw)
+      if: matrix.cfg.os == 'windows-latest'
+      run: |
+        # run 'ridk version'
+        $abi, $plat = $(ruby -e "STDOUT.write RbConfig::CONFIG['ruby_version'] + ' ' + RUBY_PLATFORM").split(' ')
+        if (($abi -ge '2.4') -and $plat.Contains('mingw')) {
+          ridk version
+        } else {
+          echo 'ridk is unavailable'
+        }
+    - name: Subprocess test
+      run: ruby test_subprocess.rb
+    - name: OpenSSL version
+      run: ruby -ropenssl -e 'puts OpenSSL::OPENSSL_LIBRARY_VERSION'
+    - name: OpenSSL test
+      run: ruby -ropen-uri -e 'puts open(%{https://rubygems.org/}) { |f| f.read(1024) }'
+    - name: C extension test
+      if: endsWith(matrix.cfg.ruby, 'mswin') == false
+      run: gem install json:2.2.0 --no-document
+    - name: C extension test (mswin cmd)
+      if: endsWith(matrix.cfg.ruby, 'mswin')
+      shell: cmd
+      run: |
+        call %VCVARS%
+        gem install json:2.2.0 --no-document
+    - name: C extension test (mswin ps1)
+      if: endsWith(matrix.cfg.ruby, 'mswin')
+      run: |
+        cmd.exe /c "$env:VCVARS && set" | Foreach-Object {
+          $p, $v = $_.split('=')
+          Set-Item -path env:$p -value $v
+        }
+        gem install json:2.2.0 --no-document
     - run: bundle --version
     - run: bundle install
     - run: bundle exec rake --version

--- a/generate-windows-versions.rb
+++ b/generate-windows-versions.rb
@@ -24,7 +24,9 @@ versions = entries.select { |entry|
   [version, entry[:href]]
 }.to_h
 
-versions['head'] = 'https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z'
+versions['head']  = 'https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z'
+versions['mingw'] = 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z'
+versions['mswin'] = 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z'
 
 js = "export const versions = #{JSON.pretty_generate(versions)}\n"
 File.write 'windows-versions.js', js

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function parseRubyEngineAndVersion(rubyVersion) {
   }
 
   let engine, version
-  if (rubyVersion.match(/^\d+/)) { // X.Y.Z => ruby-X.Y.Z
+  if (rubyVersion.match(/^(\d+|head|mingw|mswin)/)) { // X.Y.Z => ruby-X.Y.Z
     engine = 'ruby'
     version = rubyVersion
   } else if (!rubyVersion.includes('-')) { // myruby -> myruby-stableVersion
@@ -55,7 +55,6 @@ function parseRubyEngineAndVersion(rubyVersion) {
   } else { // engine-X.Y.Z
     [engine, version] = rubyVersion.split('-', 2)
   }
-
   return [engine, version]
 }
 

--- a/windows-versions.js
+++ b/windows-versions.js
@@ -24,5 +24,7 @@ export const versions = {
   "2.6.4": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.4-1/rubyinstaller-2.6.4-1-x64.7z",
   "2.6.5": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-2.6.5-1-x64.7z",
   "2.7.0": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.0-1/rubyinstaller-2.7.0-1-x64.7z",
-  "head": "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z"
+  "head": "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z",
+  "mingw": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z",
+  "mswin": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z"
 }

--- a/windows.js
+++ b/windows.js
@@ -33,10 +33,12 @@ export async function install(platform, ruby) {
   const rubyPrefix = `${drive}:\\${base}`
 
   const [hostedRuby, msys2] = await linkMSYS2()
-  setupPath(msys2, rubyPrefix)
+  setupPath((ruby === 'ruby-mswin' ? null : msys2), rubyPrefix)
 
   if (version.startsWith('2.2') || version.startsWith('2.3')) {
     core.exportVariable('SSL_CERT_FILE', `${hostedRuby}\\ssl\\cert.pem`)
+  } else if (version === 'mswin') {
+    setupMSWin(hostedRuby)
   }
 
   if (!fs.existsSync(`${rubyPrefix}\\bin\\bundle.cmd`)) {
@@ -44,6 +46,29 @@ export async function install(platform, ruby) {
   }
 
   return rubyPrefix
+}
+
+// all standard msvc OpenSSL builds use C:\Program Files\Common Files\SSL
+// as per openssl/openssl
+function setupMSWin(hostedRuby) {
+  // create cert dir
+  const msCertDir = 'C:\\Program Files\\Common Files\\SSL\\certs'
+  if (!fs.existsSync(msCertDir)) {
+    fs.mkdirSync(msCertDir, { recursive: true })
+  }
+
+  // Copy cert file
+  const msCert = 'C:\\Program Files\\Common Files\\SSL\\cert.pem'
+  if (!fs.existsSync(msCert)) {
+    const ri2Cert = `${hostedRuby}\\ssl\\cert.pem`
+    if (fs.existsSync(ri2Cert)) {
+      fs.copyFileSync(ri2Cert, msCert)
+    }
+  }
+
+  // add convenience VCVARS env variable for msvc use
+  // depends on single Visual Studio version being available in Actions image
+  core.exportVariable('VCVARS', '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"')
 }
 
 async function linkMSYS2() {
@@ -57,7 +82,9 @@ async function linkMSYS2() {
 
   const hostedMSYS2 = `${latestHostedRuby}\\msys64`
   const msys2 = 'C:\\msys64'
-  await exec.exec(`cmd /c mklink /D ${msys2} ${hostedMSYS2}`)
+  if (!fs.existsSync(msys2)) {
+    await exec.exec(`cmd /c mklink /D ${msys2} ${hostedMSYS2}`)
+  }
   return [latestHostedRuby, msys2]
 }
 


### PR DESCRIPTION
1. Add ruby-loco mingw and mswin
2. Adjust workflow for mswin - 'ridk version' & 'c extension' steps
3. Allow head, mingw, & mswin to be used without ruby prefix
4. win_names.yml_ tests the above, fails on some non Windows jobs deliberately