### PR TITLE
ruby-builder.js - Win32 - use C:\Windows\system32\tar.exe

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3387,6 +3387,7 @@ __webpack_require__.r(__webpack_exports__);
 const os = __webpack_require__(87)
 const path = __webpack_require__(622)
 const core = __webpack_require__(470)
+const exec = __webpack_require__(986)
 const io = __webpack_require__(1)
 const tc = __webpack_require__(533)
 const rubyBuilderVersions = __webpack_require__(156)
@@ -3421,7 +3422,12 @@ async function downloadAndExtract(platform, ruby) {
   console.log(url)
 
   const downloadPath = await tc.downloadTool(url)
-  await tc.extractTar(downloadPath, rubiesDir)
+  if (platform.startsWith('windows')) {
+    let args = [ '-xz', '-C', rubiesDir, '-f',  downloadPath ]
+    await exec.exec('C:\\Windows\\system32\\tar.exe', args)
+  } else {
+    await tc.extractTar(downloadPath, rubiesDir)
+  }
 
   return path.join(rubiesDir, ruby)
 }

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -1,6 +1,7 @@
 const os = require('os')
 const path = require('path')
 const core = require('@actions/core')
+const exec = require('@actions/exec')
 const io = require('@actions/io')
 const tc = require('@actions/tool-cache')
 const rubyBuilderVersions = require('./ruby-builder-versions')
@@ -35,7 +36,12 @@ async function downloadAndExtract(platform, ruby) {
   console.log(url)
 
   const downloadPath = await tc.downloadTool(url)
-  await tc.extractTar(downloadPath, rubiesDir)
+  if (platform.startsWith('windows')) {
+    let args = [ '-xz', '-C', rubiesDir, '-f',  downloadPath ]
+    await exec.exec('C:\\Windows\\system32\\tar.exe', args)
+  } else {
+    await tc.extractTar(downloadPath, rubiesDir)
+  }
 
   return path.join(rubiesDir, ruby)
 }


### PR DESCRIPTION
On Windows, the `extractTar` function in @actions/exec just shells out to the git tar command.

Use the native tar, `C:\Windows\system32\tar.exe`.