### PR TITLE
Add JRuby 9.1.17.0 for testing

### DIFF
--- a/ruby-builder-versions.js
+++ b/ruby-builder-versions.js
@@ -10,7 +10,7 @@ export function getVersions(platform) {
       "head"
     ],
     "jruby": [
-      "9.2.9.0", "9.2.10.0", "9.2.11.0",
+      "9.1.17.0", "9.2.9.0", "9.2.10.0", "9.2.11.0",
       "head"
     ],
     "truffleruby": [


### PR DESCRIPTION
The jruby-launcher needs to be tested at least one major JRuby version back. In addition, there are users out there running JRuby 9.1.x that may be unable to upgrade at present.