### PR TITLE
Make it clear this is a command to be run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Installing dependencies
 
 ```bash
-yarn
+yarn install
 ```
 
 `npm` doesn't install the correct dependencies for `eslint` so we use `yarn`.


### PR DESCRIPTION
For someone unfamiliar with `yarn`, the original output does not make it clear that it should be run as a bare command line to install dependencies. Since the default behavior is `yarn install` make that explicit in the doc.