### PR TITLE
Update for Actions Windows MSYS2 install

### DIFF
--- a/windows.js
+++ b/windows.js
@@ -8,6 +8,12 @@ const exec = require('@actions/exec')
 const tc = require('@actions/tool-cache')
 const rubyInstallerVersions = require('./windows-versions').versions
 
+// needed for 2.2, 2.3, and mswin, cert file used by Git for Windows
+const certFile = 'C:\\Program Files\\Git\\mingw64\\ssl\\cert.pem'
+
+// standard MSYS2 location, found by 'devkit'
+const msys2 = 'C:\\msys64'
+
 export function getAvailableVersions(platform, engine) {
   if (engine === 'ruby') {
     return Object.keys(rubyInstallerVersions)
@@ -33,11 +39,8 @@ export async function install(platform, ruby) {
   await exec.exec('7z', ['x', downloadPath, `-xr!${base}\\share\\doc`, `-o${drive}:\\`], { silent: true })
   const rubyPrefix = `${drive}:\\${base}`
 
-  // we use certs and embedded MSYS2 from hostedRuby
-  const hostedRuby = latestHostedRuby()
-
   let toolchainPaths = (version === 'mswin') ?
-    await setupMSWin(hostedRuby) : await setupMingw(hostedRuby, version)
+    await setupMSWin() : await setupMingw(version)
   const newPathEntries = [`${rubyPrefix}\\bin`, ...toolchainPaths]
 
   // Install Bundler if needed
@@ -48,46 +51,53 @@ export async function install(platform, ruby) {
   return [rubyPrefix, newPathEntries]
 }
 
-function latestHostedRuby() {
+// Remove when Actions Windows image contains MSYS2 install
+async function symLinkToEmbeddedMSYS2() {
   const toolCacheVersions = tc.findAllVersions('Ruby')
   toolCacheVersions.sort()
   if (toolCacheVersions.length === 0) {
     throw new Error('Could not find MSYS2 in the toolcache')
   }
   const latestVersion = toolCacheVersions.slice(-1)[0]
-  return tc.find('Ruby', latestVersion)
+  const hostedRuby = tc.find('Ruby', latestVersion)
+  await exec.exec(`cmd /c mklink /D ${msys2} ${hostedRuby}\\msys64`)
 }
 
-async function setupMingw(hostedRuby, version) {
+async function setupMingw(version) {
   if (version.startsWith('2.2') || version.startsWith('2.3')) {
-    core.exportVariable('SSL_CERT_FILE', `${hostedRuby}\\ssl\\cert.pem`)
+    core.exportVariable('SSL_CERT_FILE', certFile)
   }
 
-  // Link to embedded MSYS2 in hostedRuby
-  const msys2 = 'C:\\msys64'
+  // Remove when Actions Windows image contains MSYS2 install
   if (!fs.existsSync(msys2)) {
-    const hostedMSYS2 = `${hostedRuby}\\msys64`
-    await exec.exec(`cmd /c mklink /D ${msys2} ${hostedMSYS2}`)
+    await symLinkToEmbeddedMSYS2()
   }
 
   return [`${msys2}\\mingw64\\bin`, `${msys2}\\usr\\bin`]
 }
 
-async function setupMSWin(hostedRuby) {
+async function setupMSWin() {
   // All standard MSVC OpenSSL builds use C:\Program Files\Common Files\SSL
   const certsDir = 'C:\\Program Files\\Common Files\\SSL\\certs'
   if (!fs.existsSync(certsDir)) {
     fs.mkdirSync(certsDir)
   }
 
-  // Copy cert.pem from hosted Ruby
+  // cert.pem location is hard-coded by OpenSSL msvc builds
   const cert = 'C:\\Program Files\\Common Files\\SSL\\cert.pem'
   if (!fs.existsSync(cert)) {
-    const hostedCert = `${hostedRuby}\\ssl\\cert.pem`
-    fs.copyFileSync(hostedCert, cert)
+    fs.copyFileSync(certFile, cert)
   }
 
-  return addVCVARSEnv()
+  // Remove when Actions Windows image contains MSYS2 install
+  if (!fs.existsSync(msys2)) {
+    await symLinkToEmbeddedMSYS2()
+  }
+
+  let pathAry = addVCVARSEnv()
+  // add MSYS2 paths for misc gnu utilities like bison and ragel
+  pathAry.push(`${msys2}\\mingw64\\bin`, `${msys2}\\usr\\bin`)
+  return pathAry
 }
 
 /* Sets MSVC environment for use in Actions


### PR DESCRIPTION
1. Use 'Git for Windows' cert.pem file
2. Add MSYS2 to path for mswin (after msvc additions)
3. Rearrange code for cleanup when MSYS2 is added to Window image

The comment below precedes code that can be removed when MSYS2 is added.
```
// Remove when Actions Windows image contains MSYS2 install
```

