### PR TITLE
Windows 2.2 & 2.3 - install old MSYS DevKit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,17 @@ jobs:
     - name: build compiler
       run: |
         ruby -e "puts 'build compiler: ' + RbConfig::CONFIG.fetch('CC_VERSION_MESSAGE', 'unknown').lines.first"
-    - name: ridk version (mingw)
+    - name: gcc and ridk version (mingw)
       if: startsWith(matrix.os, 'windows')
       run: |
         $abi, $plat = $(ruby -e "STDOUT.write RbConfig::CONFIG['ruby_version'] + ' ' + RUBY_PLATFORM").split(' ')
-        if (($abi -ge '2.4') -and $plat.Contains('mingw')) {
-          ridk version
-        } else {
-          echo 'ridk is unavailable'
+        if ($plat.Contains('mingw')) {
+          gcc --version
+          if ($abi -ge '2.4') {
+            ridk version
+          } else {
+            echo 'ridk is unavailable'
+          }
         }
     - name: Subprocess test
       run: ruby test_subprocess.rb
@@ -87,14 +90,17 @@ jobs:
     - name: build compiler
       run: |
         ruby -e "puts 'build compiler: ' + RbConfig::CONFIG.fetch('CC_VERSION_MESSAGE', 'unknown').lines.first"
-    - name: ridk version (mingw)
-      if: startsWith(matrix.cfg.os, 'windows')
+    - name: gcc and ridk version (mingw)
+      if: startsWith(matrix.os, 'windows')
       run: |
         $abi, $plat = $(ruby -e "STDOUT.write RbConfig::CONFIG['ruby_version'] + ' ' + RUBY_PLATFORM").split(' ')
-        if (($abi -ge '2.4') -and $plat.Contains('mingw')) {
-          ridk version
-        } else {
-          echo 'ridk is unavailable'
+        if ($plat.Contains('mingw')) {
+          gcc --version
+          if ($abi -ge '2.4') {
+            ridk version
+          } else {
+            echo 'ridk is unavailable'
+          }
         }
     - name: Subprocess test
       run: ruby test_subprocess.rb

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ It is recommended to first get your build working on Ubuntu and macOS before try
 * The default shell on Windows is not Bash but [PowerShell](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
   This can lead issues such as multi-line scripts [not working as expected](https://github.com/ruby/setup-ruby/issues/13).
 * The `PATH` contains [multiple compiler toolchains](https://github.com/ruby/setup-ruby/issues/19). Use `where.exe` to debug which tool is used.
-* MSYS2 is prepended to the `PATH`, similar to what RubyInstaller2 does.
+* For Rubies 2.4 and later, MSYS2 is prepended to the `Path`, similar to what RubyInstaller2 does.
+* For Rubies 2.2 and 2.3, the DevKit MSYS tools are installed and prepended to the `Path`.
 * JRuby on Windows has a known bug that `bundle exec rake` [fails](https://github.com/ruby/setup-ruby/issues/18).
 
 ## Limitations

--- a/windows.js
+++ b/windows.js
@@ -11,9 +11,14 @@ const rubyInstallerVersions = require('./windows-versions').versions
 // needed for 2.2, 2.3, and mswin, cert file used by Git for Windows
 const certFile = 'C:\\Program Files\\Git\\mingw64\\ssl\\cert.pem'
 
-// standard MSYS2 location, found by 'devkit'
+// standard MSYS2 location, found by 'devkit.rb'
 const msys2 = 'C:\\msys64'
 const msys2PathEntries = [`${msys2}\\mingw64\\bin`, `${msys2}\\usr\\bin`]
+
+// location & path for old RubyInstaller DevKit (MSYS), Ruby 2.2 and 2.3
+const msys = 'C:\\DevKit64'
+const msysPathEntries = [`${msys}\\mingw\\x86_64-w64-mingw32\\bin`,
+  `${msys}\\mingw\\bin`, `${msys}\\bin`]
 
 export function getAvailableVersions(platform, engine) {
   if (engine === 'ruby') {
@@ -67,14 +72,32 @@ async function symLinkToEmbeddedMSYS2() {
 async function setupMingw(version) {
   if (version.startsWith('2.2') || version.startsWith('2.3')) {
     core.exportVariable('SSL_CERT_FILE', certFile)
-  }
+    await installMSYS()
+    return msysPathEntries
+  } else {
+    // Remove when Actions Windows image contains MSYS2 install
+    if (!fs.existsSync(msys2)) {
+      await symLinkToEmbeddedMSYS2()
+    }
 
-  // Remove when Actions Windows image contains MSYS2 install
-  if (!fs.existsSync(msys2)) {
-    await symLinkToEmbeddedMSYS2()
+    return msys2PathEntries
   }
+}
 
-  return msys2PathEntries
+// Ruby 2.2 and 2.3
+async function installMSYS() {
+  const url = 'https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe'
+
+  const downloadPath = await tc.downloadTool(url)
+
+  await exec.exec(`7z x ${downloadPath} -o${msys}`)
+
+  // below are set in the old devkit.rb file ?
+  core.exportVariable('RI_DEVKIT', msys)
+  core.exportVariable('CC' , 'gcc')
+  core.exportVariable('CXX', 'g++')
+  core.exportVariable('CPP', 'cpp')
+  core.info('Installed RubyInstaller DevKit for Ruby 2.2 or 2.3')
 }
 
 async function setupMSWin() {


### PR DESCRIPTION
Three commits:

1. 'windows.js - install old MSYS devkit for MinGW 2.2 and 2.3' - adds code to install MSYS DevKit for Windows MinGW  2.2 and 2.3 Rubies

2. 'Actions - add gcc --version output for MinGW Rubies' - added code to show version of gcc in Path.  2.2 and 2.3 should show 4.7.2 gcc, 2.4 and later should show 8.3.0 or later

3. 'README.md - add info re MSYS install for MinGW 2.2 and 2.3 Rubies'