### PR TITLE
Windows MSYS - move install to ssd drive

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4807,6 +4807,9 @@ const exec = __webpack_require__(986)
 const tc = __webpack_require__(533)
 const rubyInstallerVersions = __webpack_require__(471).versions
 
+// Extract to SSD, see https://github.com/ruby/setup-ruby/pull/14
+const drive = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
+
 // needed for 2.2, 2.3, and mswin, cert file used by Git for Windows
 const certFile = 'C:\\Program Files\\Git\\mingw64\\ssl\\cert.pem'
 
@@ -4815,7 +4818,7 @@ const msys2 = 'C:\\msys64'
 const msys2PathEntries = [`${msys2}\\mingw64\\bin`, `${msys2}\\usr\\bin`]
 
 // location & path for old RubyInstaller DevKit (MSYS), Ruby 2.2 and 2.3
-const msys = 'C:\\DevKit64'
+const msys = `${drive}:\\DevKit64`
 const msysPathEntries = [`${msys}\\mingw\\x86_64-w64-mingw32\\bin`,
   `${msys}\\mingw\\bin`, `${msys}\\bin`]
 
@@ -4836,9 +4839,6 @@ async function install(platform, ruby) {
     throw new Error('URL should end in .7z')
   }
   const base = url.slice(url.lastIndexOf('/') + 1, url.length - '.7z'.length)
-
-  // Extract to SSD, see https://github.com/ruby/setup-ruby/pull/14
-  const drive = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
 
   const downloadPath = await tc.downloadTool(url)
   await exec.exec('7z', ['x', downloadPath, `-xr!${base}\\share\\doc`, `-o${drive}:\\`], { silent: true })

--- a/windows.js
+++ b/windows.js
@@ -8,6 +8,9 @@ const exec = require('@actions/exec')
 const tc = require('@actions/tool-cache')
 const rubyInstallerVersions = require('./windows-versions').versions
 
+// Extract to SSD, see https://github.com/ruby/setup-ruby/pull/14
+const drive = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
+
 // needed for 2.2, 2.3, and mswin, cert file used by Git for Windows
 const certFile = 'C:\\Program Files\\Git\\mingw64\\ssl\\cert.pem'
 
@@ -16,7 +19,7 @@ const msys2 = 'C:\\msys64'
 const msys2PathEntries = [`${msys2}\\mingw64\\bin`, `${msys2}\\usr\\bin`]
 
 // location & path for old RubyInstaller DevKit (MSYS), Ruby 2.2 and 2.3
-const msys = 'C:\\DevKit64'
+const msys = `${drive}:\\DevKit64`
 const msysPathEntries = [`${msys}\\mingw\\x86_64-w64-mingw32\\bin`,
   `${msys}\\mingw\\bin`, `${msys}\\bin`]
 
@@ -37,9 +40,6 @@ export async function install(platform, ruby) {
     throw new Error('URL should end in .7z')
   }
   const base = url.slice(url.lastIndexOf('/') + 1, url.length - '.7z'.length)
-
-  // Extract to SSD, see https://github.com/ruby/setup-ruby/pull/14
-  const drive = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
 
   const downloadPath = await tc.downloadTool(url)
   await exec.exec('7z', ['x', downloadPath, `-xr!${base}\\share\\doc`, `-o${drive}:\\`], { silent: true })


### PR DESCRIPTION
In my fork, the 2.2 & 2.3 tests took 14 and 16 sec.  The previous CI here took 27 ands 26 sec.

Surprised that the difference was that large.  Sorry for moving it.