### PR TITLE
Windows - set ENV['MAKE'] to avoid conflicts with other Actions tools

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4879,6 +4879,8 @@ async function symLinkToEmbeddedMSYS2() {
 }
 
 async function setupMingw(version) {
+  core.exportVariable('MAKE', 'make.exe')
+
   if (version.startsWith('2.2') || version.startsWith('2.3')) {
     core.exportVariable('SSL_CERT_FILE', certFile)
     await installMSYS(version)
@@ -4909,6 +4911,8 @@ async function installMSYS(version) {
 }
 
 async function setupMSWin() {
+  core.exportVariable('MAKE', 'nmake.exe')
+
   // All standard MSVC OpenSSL builds use C:\Program Files\Common Files\SSL
   const certsDir = 'C:\\Program Files\\Common Files\\SSL\\certs'
   if (!fs.existsSync(certsDir)) {

--- a/windows.js
+++ b/windows.js
@@ -71,6 +71,8 @@ async function symLinkToEmbeddedMSYS2() {
 }
 
 async function setupMingw(version) {
+  core.exportVariable('MAKE', 'make.exe')
+
   if (version.startsWith('2.2') || version.startsWith('2.3')) {
     core.exportVariable('SSL_CERT_FILE', certFile)
     await installMSYS(version)
@@ -101,6 +103,8 @@ async function installMSYS(version) {
 }
 
 async function setupMSWin() {
+  core.exportVariable('MAKE', 'nmake.exe')
+
   // All standard MSVC OpenSSL builds use C:\Program Files\Common Files\SSL
   const certsDir = 'C:\\Program Files\\Common Files\\SSL\\certs'
   if (!fs.existsSync(certsDir)) {


### PR DESCRIPTION
To avoid things like:
```yml
    env:
      MAKE: "make" # to not try to use gmake on Windows
```

I had similar code in pkgs.  Should be here.  I also checked, and this is the last of things affecting 'build tools' (that have been noticed)...