### PR TITLE
gem install bundler - add '--conservative', small README.md change

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,5 @@ Please [update](https://github.com/ruby/setup-ruby/releases/tag/v1.13.0) if you 
 ## Credits
 
 The current maintainer of this action is @eregon.
-Most of the Windows logic is from https://github.com/MSP-Greg/actions-ruby by MSP-Greg.
+Most of the Windows logic is based on work by MSP-Greg.
 Many thanks to MSP-Greg and Lars Kanis for the help with Ruby Installer.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1107,7 +1107,7 @@ async function installBundler(platform, rubyPrefix, engine, rubyVersion) {
   } else if (/^\d+/.test(bundlerVersion)) {
     versionArray = ['-v', `~> ${bundlerVersion}`]
   } else if (bundlerVersion === 'latest') {
-    versionArray = []
+    versionArray = ['-v', '>= 2.1']
   } else {
     throw new Error(`Cannot parse bundler input: ${bundlerVersion}`)
   }
@@ -1117,7 +1117,7 @@ async function installBundler(platform, rubyPrefix, engine, rubyVersion) {
   } else if (bundlerVersion === '1' && engine === 'truffleruby') {
     console.log(`Using the Bundler version shipped with ${engine}`)
   } else {
-    await exec.exec(path.join(rubyPrefix, 'bin', 'gem'), ['install', 'bundler', ...versionArray, '--no-document'])
+    await exec.exec(path.join(rubyPrefix, 'bin', 'gem'), ['install', 'bundler', ...versionArray, '--no-document', '--conservative'])
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ async function installBundler(platform, rubyPrefix, engine, rubyVersion) {
   } else if (/^\d+/.test(bundlerVersion)) {
     versionArray = ['-v', `~> ${bundlerVersion}`]
   } else if (bundlerVersion === 'latest') {
-    versionArray = []
+    versionArray = ['-v', '>= 2.1']
   } else {
     throw new Error(`Cannot parse bundler input: ${bundlerVersion}`)
   }
@@ -159,7 +159,7 @@ async function installBundler(platform, rubyPrefix, engine, rubyVersion) {
   } else if (bundlerVersion === '1' && engine === 'truffleruby') {
     console.log(`Using the Bundler version shipped with ${engine}`)
   } else {
-    await exec.exec(path.join(rubyPrefix, 'bin', 'gem'), ['install', 'bundler', ...versionArray, '--no-document'])
+    await exec.exec(path.join(rubyPrefix, 'bin', 'gem'), ['install', 'bundler', ...versionArray, '--no-document', '--conservative'])
   }
 }
 


### PR DESCRIPTION
Two commits:

1. 'gem install bundler - add `--conservative`' - to avoid unnecessary bundler installs, especially on master

2. `README.md - remove reference to MSP-Greg/actions-ruby` - Preferred repo is now MSP-Greg/setup-ruby-pkgs