### PR TITLE
Add support for setting a working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The version of Bundler to install. Either none, 1, 2, latest or Gemfile.lock. The default tries Gemfile.lock and otherwise uses latest.'
     required: false
     default: 'default'
+  working-directory:
+    description: 'The working directory to use for this path. Useful if files like .ruby-version are somewhere other than the root of your repository. Defaults to leaving it unchanged.'
+    required: false
+    default: '.'
 outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'

--- a/dist/index.js
+++ b/dist/index.js
@@ -965,6 +965,7 @@ const common = __webpack_require__(239)
 
 async function run() {
   try {
+    process.chdir(core.getInput('working-directory'))
     const platform = common.getVirtualEnvironmentName()
     const [engine, version] = parseRubyEngineAndVersion(core.getInput('ruby-version'))
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const common = require('./common')
 
 export async function run() {
   try {
+    process.chdir(core.getInput('working-directory'))
     const platform = common.getVirtualEnvironmentName()
     const [engine, version] = parseRubyEngineAndVersion(core.getInput('ruby-version'))
 


### PR DESCRIPTION
This commit adds a `working-directory` option. This is useful for cases where files like `.ruby-version` and `Gemfile.lock` aren't located in the root directory. In my case, this is because I'm working in a monorepo, where my Ruby project is located in its own subfolder.