### PR TITLE
Compensate for premature close errors on cache restore

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2420,7 +2420,19 @@ async function bundleInstall(platform, engine, version) {
   console.log(`Cache key: ${key}`)
 
   // restore cache & install
-  const cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+  let cachedKey = null
+  try {
+    cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+  } catch (error) {
+    var isPrematureClose = error.code === 'ERR_STREAM_PREMATURE_CLOSE'
+    if(isPrematureClose){
+      console.log("There was a premature stream close error while attempting to restore the cache. Making an additional attempt now.")
+      cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+    } else {
+      throw error
+    }
+  }
+
   if (cachedKey) {
     console.log(`Found cache for key: ${cachedKey}`)
   }

--- a/index.js
+++ b/index.js
@@ -234,7 +234,19 @@ async function bundleInstall(platform, engine, version) {
   console.log(`Cache key: ${key}`)
 
   // restore cache & install
-  const cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+  let cachedKey = null
+  try {
+    cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+  } catch (error) {
+    var isPrematureClose = error.code === 'ERR_STREAM_PREMATURE_CLOSE'
+    if(isPrematureClose){
+      console.log("There was a premature stream close error while attempting to restore the cache. Making an additional attempt now.")
+      cachedKey = await cache.restoreCache(paths, key, restoreKeys)
+    } else {
+      throw error
+    }
+  }
+
   if (cachedKey) {
     console.log(`Found cache for key: ${cachedKey}`)
   }


### PR DESCRIPTION
Our buils is running into quite a few intermittent premature stream close errors (`##[error] Premature close`) while using ruby/setup-ruby (perhaps once in every 30 runs).  I tracked the source of the error down to the `restoreCache` call, and added a retry step on restoring the cache.  I believe that a single retry will be enough in most cases because the issue is quite intermittent. 

An example:
![Screen Shot 2020-06-22 at 11 06 11 AM](https://user-images.githubusercontent.com/55660/85309585-6e6e0280-b478-11ea-8d9e-cdf4e9f699b1.png)

I believe that our build may be more apt to experience these errors because our cached bundle is rather large (~304 MB).

An example of the retry working:
![Screen Shot 2020-06-22 at 11 08 01 AM](https://user-images.githubusercontent.com/55660/85309768-aecd8080-b478-11ea-83d0-9c07d334db4b.png)
