### PR TITLE
Add support for `gems.rb`/`gems.locked` during `bundle install`.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51557,14 +51557,26 @@ async function installBundler(bundlerVersionInput, platform, rubyPrefix, engine,
 }
 
 async function bundleInstall(platform, engine, version) {
-  if (!fs.existsSync('Gemfile')) {
-    console.log('No Gemfile, skipping "bundle install" and caching')
-    return
+  if (await bundleInstallSpecific('gems.rb', 'gems.locked', platform, engine, version)) {
+    return true
+  }
+
+  if (await bundleInstallSpecific('Gemfile', 'Gemfile.lock', platform, engine, version)) {
+    return true
+  }
+
+  console.log('No Gemfile/gems.rb, skipping "bundle install" and caching')
+}
+
+async function bundleInstallSpecific(gemsPath, lockPath, platform, engine, version) {
+  if (!fs.existsSync(gemsPath)) {
+    return false
   }
 
   // config
   const path = 'vendor/bundle'
-  const hasGemfileLock = fs.existsSync('Gemfile.lock');
+  const hasGemfileLock = fs.existsSync(lockPath)
+
   if (hasGemfileLock) {
     await exec.exec('bundle', ['config', '--local', 'deployment', 'true'])
   }
@@ -51576,9 +51588,9 @@ async function bundleInstall(platform, engine, version) {
   let key = baseKey
   let restoreKeys
   if (hasGemfileLock) {
-    key += `-Gemfile.lock-${await common.hashFile('Gemfile.lock')}`
+    key += `-${lockPath}-${await common.hashFile(lockPath)}`
     // If only Gemfile.lock we can reuse some of the cache (but it will keep old gem versions in the cache)
-    restoreKeys = [`${baseKey}-Gemfile.lock-`]
+    restoreKeys = [`${baseKey}-${lockPath}-`]
   } else {
     // Only exact key, to never mix native gems of different platforms or Ruby versions
     restoreKeys = []

--- a/index.js
+++ b/index.js
@@ -213,14 +213,26 @@ async function installBundler(bundlerVersionInput, platform, rubyPrefix, engine,
 }
 
 async function bundleInstall(platform, engine, version) {
-  if (!fs.existsSync('Gemfile')) {
-    console.log('No Gemfile, skipping "bundle install" and caching')
-    return
+  if (await bundleInstallSpecific('gems.rb', 'gems.locked', platform, engine, version)) {
+    return true
+  }
+
+  if (await bundleInstallSpecific('Gemfile', 'Gemfile.lock', platform, engine, version)) {
+    return true
+  }
+
+  console.log('No Gemfile/gems.rb, skipping "bundle install" and caching')
+}
+
+async function bundleInstallSpecific(gemsPath, lockPath, platform, engine, version) {
+  if (!fs.existsSync(gemsPath)) {
+    return false
   }
 
   // config
   const path = 'vendor/bundle'
-  const hasGemfileLock = fs.existsSync('Gemfile.lock');
+  const hasGemfileLock = fs.existsSync(lockPath)
+
   if (hasGemfileLock) {
     await exec.exec('bundle', ['config', '--local', 'deployment', 'true'])
   }
@@ -232,9 +244,9 @@ async function bundleInstall(platform, engine, version) {
   let key = baseKey
   let restoreKeys
   if (hasGemfileLock) {
-    key += `-Gemfile.lock-${await common.hashFile('Gemfile.lock')}`
+    key += `-${lockPath}-${await common.hashFile(lockPath)}`
     // If only Gemfile.lock we can reuse some of the cache (but it will keep old gem versions in the cache)
-    restoreKeys = [`${baseKey}-Gemfile.lock-`]
+    restoreKeys = [`${baseKey}-${lockPath}-`]
   } else {
     // Only exact key, to never mix native gems of different platforms or Ruby versions
     restoreKeys = []


### PR DESCRIPTION
  Fixes part of #52 - doesn't work with `gems.rb`. 