### PR TITLE
Fixup bundler version for rubies with bundler as a default gem

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51402,6 +51402,8 @@ async function installBundler(bundlerVersionInput, lockFile, platform, rubyPrefi
     const gem = path.join(rubyPrefix, 'bin', 'gem')
     await exec.exec(gem, ['install', 'bundler', '-v', `~> ${bundlerVersion}`, '--no-document'])
   }
+
+  core.exportVariable('BUNDLER_VERSION', bundlerVersion)
 }
 
 async function bundleInstall(gemfile, lockFile, platform, engine, version) {

--- a/index.js
+++ b/index.js
@@ -230,6 +230,8 @@ async function installBundler(bundlerVersionInput, lockFile, platform, rubyPrefi
     const gem = path.join(rubyPrefix, 'bin', 'gem')
     await exec.exec(gem, ['install', 'bundler', '-v', `~> ${bundlerVersion}`, '--no-document'])
   }
+
+  core.exportVariable('BUNDLER_VERSION', bundlerVersion)
 }
 
 async function bundleInstall(gemfile, lockFile, platform, engine, version) {


### PR DESCRIPTION
Basically use specific bundler version until lockfile is created. Fixes #117, test run which previously failed can be found [here](https://github.com/ojab/watir-rails/runs/1500872128).