### PR TITLE
Pass BUNDLER_VERSION only to commands that need it and not for the whole workflow

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51257,12 +51257,12 @@ async function setupRuby(options = {}) {
   if (inputs['bundler'] !== 'none') {
     const [gemfile, lockFile] = detectGemfiles()
 
-    await common.measure('Installing Bundler', async () =>
+    const bundlerVersion = await common.measure('Installing Bundler', async () =>
       installBundler(inputs['bundler'], lockFile, platform, rubyPrefix, engine, version))
 
     if (inputs['bundler-cache'] === 'true') {
       await common.measure('bundle install', async () =>
-          bundleInstall(gemfile, lockFile, platform, engine, version))
+          bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion))
     }
   }
 
@@ -51425,10 +51425,10 @@ async function installBundler(bundlerVersionInput, lockFile, platform, rubyPrefi
     await exec.exec(gem, ['install', 'bundler', '-v', `~> ${bundlerVersion}`, '--no-document'])
   }
 
-  core.exportVariable('BUNDLER_VERSION', bundlerVersion)
+  return bundlerVersion
 }
 
-async function bundleInstall(gemfile, lockFile, platform, engine, version) {
+async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, bundlerVersion) {
   if (gemfile === null) {
     console.log('Could not determine gemfile path, skipping "bundle install" and caching')
     return false
@@ -51436,20 +51436,21 @@ async function bundleInstall(gemfile, lockFile, platform, engine, version) {
 
   // config
   const path = 'vendor/bundle'
+  const optionsWithBundlerVersion = {options: {env: {...process.env, BUNDLER_VERSION: bundlerVersion}}}
 
-  await exec.exec('bundle', ['config', '--local', 'path', path])
+  await exec.exec('bundle', ['config', '--local', 'path', path], optionsWithBundlerVersion)
 
   if (fs.existsSync(lockFile)) {
-    await exec.exec('bundle', ['config', '--local', 'deployment', 'true'])
+    await exec.exec('bundle', ['config', '--local', 'deployment', 'true'], optionsWithBundlerVersion)
   } else {
     // Generate the lockfile so we can use it to compute the cache key.
     // This will also automatically pick up the latest gem versions compatible with the Gemfile.
-    await exec.exec('bundle', ['lock'])
+    await exec.exec('bundle', ['lock'], optionsWithBundlerVersion)
   }
 
   // cache key
   const paths = [path]
-  const baseKey = await computeBaseKey(platform, engine, version, lockFile)
+  const baseKey = await computeBaseKey(platform, engine, rubyVersion, lockFile)
   const key = `${baseKey}-${await common.hashFile(lockFile)}`
   // If only Gemfile.lock changes we can reuse part of the cache, and clean old gem versions below
   const restoreKeys = [`${baseKey}-`]


### PR DESCRIPTION
Looks like we can't delete environment variable and we cannot set envvar for the single step from JS, so let's just set requested bundler version to envvar if it's set, so
```yaml
- use: ruby/setup-ruby@v1
  with:
    ruby-version: 2.7
  env:
    BUNDLER_VERSION: 1
```
will do the trick.