### PR TITLE
Document the `bundler: "x.y.z"` feature

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: 'default'
   bundler:
     description: |
-      The version of Bundler to install. Either 'none', 'latest', 'Gemfile.lock', or a version number (eg 1, 2, "2.1.4").
+      The version of Bundler to install. Either 'none', 'latest', 'Gemfile.lock', or a version number (e.g., 1, 2, 2.1.4).
       For 'Gemfile.lock', the version is determined based on the BUNDLED WITH section from the file Gemfile.lock, $BUNDLE_GEMFILE.lock or gems.locked.
       Defaults to 'Gemfile.lock' if the file exists and 'latest' otherwise.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: 'default'
   bundler:
     description: |
-      The version of Bundler to install. Either 'none', 1, 2, 'latest' or 'Gemfile.lock'.
+      The version of Bundler to install. Either 'none', 'latest', 'Gemfile.lock', or a version number (eg 1, 2, "2.1.4").
       For 'Gemfile.lock', the version is determined based on the BUNDLED WITH section from the file Gemfile.lock, $BUNDLE_GEMFILE.lock or gems.locked.
       Defaults to 'Gemfile.lock' if the file exists and 'latest' otherwise.
     required: false


### PR DESCRIPTION
It looks like we can specify the bundler version to install with, eg, `bundler: "2.1.4"`, though the documentation implies that we can only install the latest version of bundler 1 or bundler 2.  How about this documentation tweak?

https://github.com/ruby/setup-ruby/issues/123