### PR TITLE
Remove bundler enforcement on ruby 2.3

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -72,9 +72,6 @@ export async function installBundler(bundlerVersionInput, lockFile, platform, ru
   if (engine === 'ruby' && rubyVersion.match(/^2\.[012]/)) {
     console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
     bundlerVersion = '1'
-  } else if (engine === 'ruby' && rubyVersion.startsWith('2.3')) {
-    console.log('Ruby 2.3 has a bug with Bundler 2 (https://github.com/rubygems/rubygems/issues/3570), using Bundler 1 instead on Ruby 2.3')
-    bundlerVersion = '1'
   } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
     console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
     bundlerVersion = '1'

--- a/dist/index.js
+++ b/dist/index.js
@@ -44608,9 +44608,6 @@ async function installBundler(bundlerVersionInput, lockFile, platform, rubyPrefi
   if (engine === 'ruby' && rubyVersion.match(/^2\.[012]/)) {
     console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
     bundlerVersion = '1'
-  } else if (engine === 'ruby' && rubyVersion.startsWith('2.3')) {
-    console.log('Ruby 2.3 has a bug with Bundler 2 (https://github.com/rubygems/rubygems/issues/3570), using Bundler 1 instead on Ruby 2.3')
-    bundlerVersion = '1'
   } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
     console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
     bundlerVersion = '1'


### PR DESCRIPTION
The fix for rubygems/rubygems#3570 was released with bundler 2.2.0.rc.1.