### PR TITLE
Add a comment about version quotations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # Due to a bug discussed on https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.5, 2.6, 2.7, '3.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
As described in the comment, due to a bug discussed on https://github.com/actions/runner/issues/849,
we currently have to use quotes for  '3.0' as a workaround.
This change makes it easy for people not to remove quotes as they misunderstand it's a typo.