### PR TITLE
JRuby 9.3 (head) and forward ships bundler

### DIFF
--- a/common.js
+++ b/common.js
@@ -60,6 +60,8 @@ export function isBundler2Default(engine, rubyVersion) {
     return isHeadVersion(rubyVersion) || floatVersion(rubyVersion) >= 2.7
   } else if (engine === 'truffleruby') {
     return isHeadVersion(rubyVersion)
+  } else if (engine === 'jruby') {
+    return isHeadVersion(rubyVersion)
   } else {
     return false
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -32852,6 +32852,8 @@ function isBundler2Default(engine, rubyVersion) {
     return isHeadVersion(rubyVersion) || floatVersion(rubyVersion) >= 2.7
   } else if (engine === 'truffleruby') {
     return isHeadVersion(rubyVersion)
+  } else if (engine === 'jruby') {
+    return isHeadVersion(rubyVersion)
   } else {
     return false
   }


### PR DESCRIPTION
JRuby 9.3 will ship with bundler and jruby-head already does.  This PR, like truffleruby, will not bother installing bundler since it is already installed.

I was confused about one thing.  When JRuby 9.3 is released how do we change this action to say bundler is already installed?  ruby-version appears to only report 'jruby' and 'jruby-head' to this JS function.  I would like to make sure when we do put out that version we are not again reinstalling bundler.