### PR TITLE
Enable SassC test on JRuby on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,10 +95,9 @@ jobs:
     - name: bash test
       shell: bash
       run: echo ~
-    # Disabled until https://github.com/jruby/jruby/issues/6648 is fixed (9.2.18.0)
-    # - name: Windows JRuby
-    #   if: startsWith(matrix.os, 'windows') && startsWith(matrix.ruby, 'jruby')
-    #   run: gem install sassc
+    - name: Windows JRuby
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.ruby, 'jruby')
+      run: gem install sassc
 
   testExactBundlerVersion:
     name: "Test with an exact Bundler version"


### PR DESCRIPTION
9.2.18.0 has been released, so this should work now.

Follow-up to #188