### PR TITLE
Add Windows MSYS2 ucrt support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -390,6 +390,13 @@ function win2nix(path) {
   return path.replace(/\\/g, '/').replace(/ /g, '\\ ')
 }
 
+// JRuby is installed after setupPath is called, so folder doesn't exist
+function rubyIsUCRT(path) {
+  return !!(fs.existsSync(path) &&
+    fs.readdirSync(path, { withFileTypes: true }).find(dirent =>
+      dirent.isFile() && dirent.name.match(/^x64-ucrt-ruby\d{3}\.dll$/)))
+}
+
 function setupPath(newPathEntries) {
   const envPath = windows ? 'Path' : 'PATH'
   const originalPath = process.env[envPath].split(path.delimiter)
@@ -411,8 +418,11 @@ function setupPath(newPathEntries) {
   // Then add new path entries using core.addPath()
   let newPath
   if (windows) {
+    // main Ruby dll determines whether mingw or ucrt build
+    let build_sys = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
+
     // add MSYS2 in path for all Rubies on Windows, as it provides a better bash shell and a native toolchain
-    const msys2 = ['C:\\msys64\\mingw64\\bin', 'C:\\msys64\\usr\\bin']
+    const msys2 = [`C:\\msys64\\${build_sys}\\bin`, 'C:\\msys64\\usr\\bin']
     newPath = [...newPathEntries, ...msys2]
   } else {
     newPath = newPathEntries
@@ -59003,11 +59013,11 @@ async function install(platform, engine, version) {
 
   let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
 
-  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
+
+  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   return rubyPrefix
 }

--- a/windows.js
+++ b/windows.js
@@ -50,11 +50,11 @@ export async function install(platform, engine, version) {
 
   let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
 
-  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
+
+  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   return rubyPrefix
 }


### PR DESCRIPTION
Add support for Windows Rubies compiled with the MSYS2 ucrt packages.

On Windows, we currently set `ENV['Path']` to include the MSYS2 build tools locations.

This provides basic *nix commands, which are often used in Actions and also build/compile scripts.  It also places the gcc compiler in the path.

With non CRuby builds, the path additions need to happen before the Ruby is installed to allow access to the `tar` command.  Currently, all CRuby builds are 7z files, so `tar` isn't needed.

Now, with ucrt builds available, we need to check the name of the main Ruby dll to determine whether it is mingw or ucrt.  Once that is determined, we can set the path additions.

I've opened this PR for review, but **it should not be merged** MSYS2 ucrt packages are available in the Actions images.

But, I've patched my fork of `setup-ruby`, and added a branch in `setup-ruby-pkgs` for it, and it's being used in [PR #2272](https://github.com/sparklemotion/nokogiri/pull/2272) in Nokogiri, and it's working fine.  Note that it must be used with `setup-ruby-pkgs`, as it is installing all the (missing) ucrt packages...

See https://github.com/actions/virtual-environments/issues/3597

Closes #193