### PR TITLE
Runtime - Add logging of both PATH removals & additions, CI - improve 'PATH' step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
     - README.md
   schedule:
     - cron: '0 7 * * SUN'
+  workflow_dispatch:
+
 jobs:
   test:
     strategy:
@@ -40,8 +42,10 @@ jobs:
         bundler-cache: true
     - run: ruby -v
     - name: PATH
-      shell: bash
-      run: echo $PATH
+      shell: pwsh
+      run: |
+        # Show PATH with Powershell
+        $f, $r = $env:PATH.split([IO.Path]::PathSeparator); $r
 
     - name: build compiler
       run: |

--- a/common.js
+++ b/common.js
@@ -154,17 +154,17 @@ export function setupPath(newPathEntries) {
   const originalPath = process.env[envPath].split(path.delimiter)
   let cleanPath = originalPath.filter(entry => !/\bruby\b/i.test(entry))
 
+  core.startGroup(`Modifying ${envPath}`)
+
   // First remove the conflicting path entries
   if (cleanPath.length !== originalPath.length) {
-    core.startGroup(`Cleaning ${envPath}`)
-    console.log(`Entries removed from ${envPath} to avoid conflicts with Ruby:`)
+    console.log(`Entries removed from ${envPath} to avoid conflicts with default Ruby:`)
     for (const entry of originalPath) {
       if (!cleanPath.includes(entry)) {
         console.log(`  ${entry}`)
       }
     }
     core.exportVariable(envPath, cleanPath.join(path.delimiter))
-    core.endGroup()
   }
 
   // Then add new path entries using core.addPath()
@@ -176,5 +176,13 @@ export function setupPath(newPathEntries) {
   } else {
     newPath = newPathEntries
   }
+  console.log(`Entries added to ${envPath} to use selected Ruby:`)
+  for (const entry of newPath) {
+    if (!cleanPath.includes(entry)) {
+      console.log(`  ${entry}`)
+    }
+  }
+  core.endGroup()
+
   core.addPath(newPath.join(path.delimiter))
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -395,17 +395,17 @@ function setupPath(newPathEntries) {
   const originalPath = process.env[envPath].split(path.delimiter)
   let cleanPath = originalPath.filter(entry => !/\bruby\b/i.test(entry))
 
+  core.startGroup(`Modifying ${envPath}`)
+
   // First remove the conflicting path entries
   if (cleanPath.length !== originalPath.length) {
-    core.startGroup(`Cleaning ${envPath}`)
-    console.log(`Entries removed from ${envPath} to avoid conflicts with Ruby:`)
+    console.log(`Entries removed from ${envPath} to avoid conflicts with default Ruby:`)
     for (const entry of originalPath) {
       if (!cleanPath.includes(entry)) {
         console.log(`  ${entry}`)
       }
     }
     core.exportVariable(envPath, cleanPath.join(path.delimiter))
-    core.endGroup()
   }
 
   // Then add new path entries using core.addPath()
@@ -417,6 +417,14 @@ function setupPath(newPathEntries) {
   } else {
     newPath = newPathEntries
   }
+  console.log(`Entries added to ${envPath} to use selected Ruby:`)
+  for (const entry of newPath) {
+    if (!cleanPath.includes(entry)) {
+      console.log(`  ${entry}`)
+    }
+  }
+  core.endGroup()
+
   core.addPath(newPath.join(path.delimiter))
 }
 


### PR DESCRIPTION
Commits:

**'Improve Path info in CI, add workflow_dispatch'** - only changes Actions, shows 'PATH' step info with each PATH segment on an individual line, display Windows Path in a normal window style.

**'Update runtime logging of Path adjustments, show additions'** - the runtime logging had a group named 'Cleaning Path'.  It only showed path deletions.  Changed name to 'Modifying Path', and added logging of path additions.