### PR TITLE
Windows: Use "ridk enable" like variable setup and add UCRT

### DIFF
--- a/common.js
+++ b/common.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const util = require('util')
 const stream = require('stream')
 const crypto = require('crypto')
+const child_process = require('child_process')
 const core = require('@actions/core')
 const { performance } = require('perf_hooks')
 
@@ -150,7 +151,7 @@ export function win2nix(path) {
 }
 
 // JRuby is installed after setupPath is called, so folder doesn't exist
-function rubyIsUCRT(path) {
+export function rubyIsUCRT(path) {
   return !!(fs.existsSync(path) &&
     fs.readdirSync(path, { withFileTypes: true }).find(dirent =>
       dirent.isFile() && dirent.name.match(/^x64-ucrt-ruby\d{3}\.dll$/)))
@@ -175,16 +176,27 @@ export function setupPath(newPathEntries) {
   }
 
   // Then add new path entries using core.addPath()
-  let newPath
+  let newPath = newPathEntries
   if (windows) {
-    // main Ruby dll determines whether mingw or ucrt build
-    let build_sys = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
+    try {
+      // Use RubyInstaller mechanisms to set various evenironment variables including the PATH to MSYS2 tools
+      // Same as "ridk enable" on the command line
+      const envbuf = child_process.execFileSync(`${newPathEntries[0]}\\ruby`, ['-rruby_installer/runtime', '-e', 'puts RubyInstaller::Runtime.msys2_installation.enable_msys_apps_per_cmd'])
+      const envvars = envbuf.toString().trim().split(/\r?\n/)
 
-    // add MSYS2 in path for all Rubies on Windows, as it provides a better bash shell and a native toolchain
-    const msys2 = [`C:\\msys64\\${build_sys}\\bin`, 'C:\\msys64\\usr\\bin']
-    newPath = [...newPathEntries, ...msys2]
-  } else {
-    newPath = newPathEntries
+      envvars.forEach( (envvar) => {
+        console.log(`SET ${envvar}`)
+        const parts = envvar.split("=", 2)
+        core.exportVariable(parts[0], parts[1])
+      })
+    } catch (ex) {
+      // main Ruby dll determines whether mingw or ucrt build
+      let build_sys = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
+
+      // add MSYS2 in path for all Rubies on Windows, as it provides a better bash shell and a native toolchain
+      const msys2 = [`C:\\msys64\\${build_sys}\\bin`, 'C:\\msys64\\usr\\bin']
+      newPath = [...newPathEntries, ...msys2]
+    }
   }
   console.log(`Entries added to ${envPath} to use selected Ruby:`)
   for (const entry of newPath) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -390,6 +390,13 @@ function win2nix(path) {
   return path.replace(/\\/g, '/').replace(/ /g, '\\ ')
 }
 
+// JRuby is installed after setupPath is called, so folder doesn't exist
+function rubyIsUCRT(path) {
+  return !!(fs.existsSync(path) &&
+    fs.readdirSync(path, { withFileTypes: true }).find(dirent =>
+      dirent.isFile() && dirent.name.match(/^x64-ucrt-ruby\d{3}\.dll$/)))
+}
+
 function setupPath(newPathEntries) {
   const envPath = windows ? 'Path' : 'PATH'
   const originalPath = process.env[envPath].split(path.delimiter)
@@ -411,8 +418,11 @@ function setupPath(newPathEntries) {
   // Then add new path entries using core.addPath()
   let newPath
   if (windows) {
+    // main Ruby dll determines whether mingw or ucrt build
+    let build_sys = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
+
     // add MSYS2 in path for all Rubies on Windows, as it provides a better bash shell and a native toolchain
-    const msys2 = ['C:\\msys64\\mingw64\\bin', 'C:\\msys64\\usr\\bin']
+    const msys2 = [`C:\\msys64\\${build_sys}\\bin`, 'C:\\msys64\\usr\\bin']
     newPath = [...newPathEntries, ...msys2]
   } else {
     newPath = newPathEntries
@@ -59003,11 +59013,11 @@ async function install(platform, engine, version) {
 
   let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
 
-  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
+
+  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   return rubyPrefix
 }

--- a/windows.js
+++ b/windows.js
@@ -50,11 +50,11 @@ export async function install(platform, engine, version) {
 
   let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
 
-  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
+
+  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   return rubyPrefix
 }

--- a/windows.js
+++ b/windows.js
@@ -56,6 +56,10 @@ export async function install(platform, engine, version) {
 
   common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
+  if (common.rubyIsUCRT(`${rubyPrefix}\\bin`)) {
+    await installUCRT()
+  }
+
   return rubyPrefix
 }
 
@@ -77,6 +81,12 @@ async function downloadAndExtract(engine, version, url, base, rubyPrefix) {
   if (common.shouldUseToolCache(engine, version)) {
     common.createToolCacheCompleteFile(rubyPrefix)
   }
+}
+
+async function installUCRT() {
+  await common.measure('Installing MSYS2 UCRT build tools', async () => {
+    cp.execSync(`pacman -S --noconfirm --noprogressbar --needed %MINGW_PACKAGE_PREFIX%-gcc`)
+  })
 }
 
 async function setupMingw(version) {


### PR DESCRIPTION
This PR adds a "ridk enable" like setup of environment variables. "ridk enable" and "ridk exec" are the preferred ways to enable MSYS2 in RubyInstaller2. This not only sets the PATH but also several other variables that are required for pkgconf, autotools, etc.

"ridk enable" mimics the variable setup of MSYS2 "bash --login", but enables powershell and cmd.exe to run MSYS2 commands.

As a fallback, in case the RubyInstaller mechanism fails, the PATH is extended to use MSYS64 with MINGW or UCRT, but no other variables are set.

The PR installs gcc when running on Windows-UCRT, since there is no UCRT capable compiler preinstalled on github actions. That might be a temporary solution until @MSP-Greg finds another way to package gcc in a faster install solution.

A Github Action run on Windows looks like so: https://github.com/larskanis/ruby-pg/runs/2972095461?check_suite_focus=true#step:3:19
