### PR TITLE
Suggest absolute path for BUNDLE_GEMFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ jobs:
         gemfile: [ rails5, rails6 ]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
-      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This ensures the gemfile can be found when a step changes the working directory.

---

A little while back, I encountered an issue when setting up CI for Rails gems and using the `bin/test` script that Rails generates.  This addition fixed it.  I had written myself a reminder to submit this PR, but, unfortunately, I didn't write down any further details.  But I hope this helps someone.
