### PR TITLE
Add Ruby 1.9 on Linux and macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019 ]
-        ruby: [ '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', ruby-head, jruby, jruby-head, truffleruby, truffleruby-head ]
+        ruby: [ 1.9, '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', ruby-head, jruby, jruby-head, truffleruby, truffleruby-head ]
         include:
         - { os: windows-2016, ruby: mingw }
         - { os: windows-2019, ruby: mingw }
         - { os: windows-2019, ruby: mswin }
         exclude:
+        - { os: windows-2016, ruby: 1.9 }
         - { os: windows-2016, ruby: debug }
         - { os: windows-2016, ruby: truffleruby }
         - { os: windows-2016, ruby: truffleruby-head }
+        - { os: windows-2019, ruby: 1.9 }
         - { os: windows-2019, ruby: debug }
         - { os: windows-2019, ruby: truffleruby }
         - { os: windows-2019, ruby: truffleruby-head }
@@ -67,14 +69,17 @@ jobs:
 
     - name: Subprocess test
       run: ruby test_subprocess.rb
-    - name: OpenSSL version
+    - name: OpenSSL compiled version
+      run: ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'
+    - name: OpenSSL loaded version
       run: ruby -ropenssl -e 'puts OpenSSL::OPENSSL_LIBRARY_VERSION'
+      if: matrix.ruby != '1.9'
     - name: OpenSSL test
       run: ruby -ropen-uri -e 'puts URI.send(:open, %{https://rubygems.org/}) { |f| f.read(1024) }'
 
     - run: gem env
     - name: C extension test
-      run: gem install json:2.2.0 --no-document
+      run: gem install json -v 2.2.0
     - run: bundle --version
     # This step is redundant with `bundler-cache: true` but is there to check a redundant `bundle install` still works
     - run: bundle install

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This action currently supports these versions of MRI, JRuby and TruffleRuby:
 
 | Interpreter | Versions |
 | ----------- | -------- |
-| `ruby` | 2.0.0, 2.1.9, 2.2, all versions from 2.3.0 until 3.0.2, head, debug, mingw, mswin |
+| `ruby` | 1.9.3, 2.0.0, 2.1.9, 2.2, all versions from 2.3.0 until 3.0.2, head, debug, mingw, mswin |
 | `jruby` | 9.1.17.0, 9.2.9.0 - 9.2.19.0, head |
 | `truffleruby` | 19.3.0 - 21.2.0, head |
 

--- a/bundler.js
+++ b/bundler.js
@@ -71,7 +71,7 @@ export async function installBundler(bundlerVersionInput, lockFile, platform, ru
     throw new Error(`Cannot parse bundler input: ${bundlerVersion}`)
   }
 
-  if (engine === 'ruby' && rubyVersion.match(/^2\.[012]/)) {
+  if (engine === 'ruby' && common.floatVersion(rubyVersion) <= 2.2) {
     console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
     bundlerVersion = '1'
   } else if (engine === 'ruby' && rubyVersion.match(/^2\.3\.[01]/)) {
@@ -91,7 +91,7 @@ export async function installBundler(bundlerVersionInput, lockFile, platform, ru
   } else {
     const gem = path.join(rubyPrefix, 'bin', 'gem')
     const bundlerVersionConstraint = bundlerVersion.match(/^\d+\.\d+\.\d+/) ? bundlerVersion : `~> ${bundlerVersion}`
-    await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint, '--no-document'])
+    await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint])
   }
 
   return bundlerVersion

--- a/common.js
+++ b/common.js
@@ -61,11 +61,11 @@ export function isBundler1Default(engine, rubyVersion) {
 
 export function isBundler2Default(engine, rubyVersion) {
   if (engine === 'ruby') {
-    return isHeadVersion(rubyVersion) || floatVersion(rubyVersion) >= 2.7
+    return floatVersion(rubyVersion) >= 2.7
   } else if (engine === 'truffleruby') {
-    return isHeadVersion(rubyVersion) || floatVersion(rubyVersion) >= 21.0
+    return floatVersion(rubyVersion) >= 21.0
   } else if (engine === 'jruby') {
-    return isHeadVersion(rubyVersion) || floatVersion(rubyVersion) >= 9.3
+    return floatVersion(rubyVersion) >= 9.3
   } else {
     return false
   }
@@ -75,8 +75,10 @@ export function floatVersion(rubyVersion) {
   const match = rubyVersion.match(/^\d+\.\d+/)
   if (match) {
     return parseFloat(match[0])
+  } else if (isHeadVersion(rubyVersion)) {
+    return 999.999
   } else {
-    return 0.0
+    throw new Error(`Could not convert version ${rubyVersion} to a float`)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ export async function setupRuby(options = {}) {
   const engineVersions = installer.getAvailableVersions(platform, engine)
   const version = validateRubyEngineAndVersion(platform, engineVersions, engine, parsedVersion)
 
-  createGemRC()
+  createGemRC(engine, version)
   envPreInstall()
 
   const rubyPrefix = await installer.install(platform, engine, version)
@@ -138,10 +138,14 @@ function validateRubyEngineAndVersion(platform, engineVersions, engine, parsedVe
   return version
 }
 
-function createGemRC() {
+function createGemRC(engine, version) {
   const gemrc = path.join(os.homedir(), '.gemrc')
   if (!fs.existsSync(gemrc)) {
-    fs.writeFileSync(gemrc, `gem: --no-document${os.EOL}`)
+    if (engine === 'ruby' && common.floatVersion(version) < 2.0) {
+      fs.writeFileSync(gemrc, `install: --no-rdoc --no-ri${os.EOL}update: --no-rdoc --no-ri${os.EOL}`)
+    } else {
+      fs.writeFileSync(gemrc, `gem: --no-document${os.EOL}`)
+    }
   }
 }
 

--- a/ruby-builder-versions.js
+++ b/ruby-builder-versions.js
@@ -1,6 +1,7 @@
 export function getVersions(platform) {
   const versions = {
     "ruby": [
+      "1.9.3-p551",
       "2.0.0-p648",
       "2.1.9",
       "2.2.10",

--- a/windows.js
+++ b/windows.js
@@ -82,7 +82,7 @@ async function downloadAndExtract(engine, version, url, base, rubyPrefix) {
 async function setupMingw(version) {
   core.exportVariable('MAKE', 'make.exe')
 
-  if (version.match(/^2\.[0123]/)) {
+  if (common.floatVersion(version) <= 2.3) {
     core.exportVariable('SSL_CERT_FILE', certFile)
     await common.measure('Installing MSYS', async () => installMSYS(version))
     return msysPathEntries


### PR DESCRIPTION
* On Windows there are no 64-bit builds of Ruby 1.9.
* Use floatVersion() in more cases instead of regexps.
* Rely on ~/.gemrc to not install gem docs.

Fixes https://github.com/ruby/setup-ruby/issues/204