### PR TITLE
Windows - Add support for ucrt & Windows-2022 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         - { os: windows-2016, ruby: mingw }
         - { os: windows-2019, ruby: mingw }
         - { os: windows-2019, ruby: mswin }
+        - { os: windows-2022, ruby: mingw }
+        - { os: windows-2022, ruby: head }
         exclude:
         - { os: windows-2016, ruby: 1.9 }
         - { os: windows-2016, ruby: debug }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019, windows-2022 ]
         ruby: [ 1.9, '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, ruby-head, jruby, jruby-head, truffleruby, truffleruby-head, truffleruby+graalvm, truffleruby+graalvm-head ]
         include:
         - { os: windows-2016, ruby: mingw }
         - { os: windows-2019, ruby: mingw }
         - { os: windows-2019, ruby: mswin }
         - { os: windows-2022, ruby: mingw }
-        - { os: windows-2022, ruby: ucrt }
-        - { os: windows-2022, ruby: head }
+        - { os: windows-2022, ruby: ucrt  }
         exclude:
         - { os: windows-2016, ruby: 1.9 }
         - { os: windows-2016, ruby: debug }
@@ -37,6 +36,12 @@ jobs:
         - { os: windows-2019, ruby: truffleruby-head }
         - { os: windows-2019, ruby: truffleruby+graalvm }
         - { os: windows-2019, ruby: truffleruby+graalvm-head }
+        - { os: windows-2022, ruby: 1.9 }
+        - { os: windows-2022, ruby: debug }
+        - { os: windows-2022, ruby: truffleruby }
+        - { os: windows-2022, ruby: truffleruby-head }
+        - { os: windows-2022, ruby: truffleruby+graalvm }
+        - { os: windows-2022, ruby: truffleruby+graalvm-head }
 
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         - { os: windows-2019, ruby: mingw }
         - { os: windows-2019, ruby: mswin }
         - { os: windows-2022, ruby: mingw }
+        - { os: windows-2022, ruby: ucrt }
         - { os: windows-2022, ruby: head }
         exclude:
         - { os: windows-2016, ruby: 1.9 }

--- a/common.js
+++ b/common.js
@@ -48,7 +48,7 @@ export async function measure(name, block) {
 }
 
 export function isHeadVersion(rubyVersion) {
-  return rubyVersion === 'head' || rubyVersion === 'debug' || rubyVersion === 'mingw' || rubyVersion === 'mswin'
+  return ['head', 'debug',  'mingw', 'mswin', 'ucrt'].includes(rubyVersion)
 }
 
 export function isStableVersion(rubyVersion) {

--- a/common.js
+++ b/common.js
@@ -155,7 +155,15 @@ export function win2nix(path) {
   return path.replace(/\\/g, '/').replace(/ /g, '\\ ')
 }
 
+// JRuby is installed after setupPath is called, so folder doesn't exist
+function rubyIsUCRT(path) {
+  return !!(fs.existsSync(path) &&
+    fs.readdirSync(path, { withFileTypes: true }).find(dirent =>
+      dirent.isFile() && dirent.name.match(/^x64-ucrt-ruby\d{3}\.dll$/)))
+}
+
 export function setupPath(newPathEntries) {
+  let win_build_sys = null
   const envPath = windows ? 'Path' : 'PATH'
   const originalPath = process.env[envPath].split(path.delimiter)
   let cleanPath = originalPath.filter(entry => !/\bruby\b/i.test(entry))
@@ -176,8 +184,11 @@ export function setupPath(newPathEntries) {
   // Then add new path entries using core.addPath()
   let newPath
   if (windows) {
+    // main Ruby dll determines whether mingw or ucrt build
+    win_build_sys = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
+
     // add MSYS2 in path for all Rubies on Windows, as it provides a better bash shell and a native toolchain
-    const msys2 = ['C:\\msys64\\mingw64\\bin', 'C:\\msys64\\usr\\bin']
+    const msys2 = [`C:\\msys64\\${win_build_sys}\\bin`, 'C:\\msys64\\usr\\bin']
     newPath = [...newPathEntries, ...msys2]
   } else {
     newPath = newPathEntries
@@ -189,4 +200,5 @@ export function setupPath(newPathEntries) {
   core.endGroup()
 
   core.addPath(newPath.join(path.delimiter))
+  return win_build_sys
 }

--- a/generate-windows-versions.rb
+++ b/generate-windows-versions.rb
@@ -28,6 +28,7 @@ versions = entries.select { |entry|
 versions['head'] = 'https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z'
 versions['mingw'] = 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z'
 versions['mswin'] = 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z'
+versions['ucrt'] = 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-ucrt.7z'
 
 js = "export const versions = #{JSON.pretty_generate(versions)}\n"
 File.binwrite 'windows-versions.js', js

--- a/index.js
+++ b/index.js
@@ -51,6 +51,13 @@ export async function setupRuby(options = {}) {
   createGemRC(engine, version)
   envPreInstall()
 
+  // JRuby can use compiled extension code, so make sure gcc exists.
+  // As of Jan-2022, JRuby compiles against msvcrt.
+  if (platform.startsWith('windows') && (engine === 'jruby') && 
+    !fs.existsSync('C:\\msys64\\mingw64\\bin\\gcc.exe')) {
+    await require('./windows').installJRubyTools()
+  }
+
   const rubyPrefix = await installer.install(platform, engine, version)
 
   // When setup-ruby is used by other actions, this allows code in them to run

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "@actions/tool-cache": "^1.7.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.28.6"
+    "@vercel/ncc": "^0.31.1"
   }
 }

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -79,7 +79,7 @@ async function downloadAndExtract(platform, engine, version, rubyPrefix) {
     return await tc.downloadTool(url)
   })
 
-  await common.measure('Extracting Ruby', async () => {
+  await common.measure('Extracting  Ruby', async () => {
     if (windows) {
       // Windows 2016 doesn't have system tar, use MSYS2's, it needs unix style paths
       await exec.exec('tar', ['-xz', '-C', common.win2nix(parentDir), '-f', common.win2nix(downloadPath)])

--- a/windows-versions.js
+++ b/windows-versions.js
@@ -45,5 +45,6 @@ export const versions = {
   "3.1.0": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.0-1/rubyinstaller-3.1.0-1-x64.7z",
   "head": "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z",
   "mingw": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z",
-  "mswin": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z"
+  "mswin": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z",
+  "ucrt": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-ucrt.7z"
 }

--- a/windows.js
+++ b/windows.js
@@ -50,13 +50,51 @@ export async function install(platform, engine, version) {
 
   let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
 
-  common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
 
+  const winMSYS2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
+
+  const virtualEnv = common.getVirtualEnvironmentName()
+
+  if (( winMSYS2Type === 'ucrt64') || !['windows-2019', 'windows-2016'].includes(virtualEnv)) {
+    await installGCCTools(winMSYS2Type)
+
+    if (!['windows-2019', 'windows-2016'].includes(virtualEnv)) {
+      await installMSY2Tools()
+    }
+  }
+
   return rubyPrefix
+}
+
+// Actions windows-2022 image does not contain any mingw or ucrt build tools.  Install tools for it,
+// and also install ucrt tools on earlier versions, which have msys2 and mingw tools preinstalled.
+async function installGCCTools(type) {
+  const downloadPath = await common.measure(`Download ${type} build tools`, async () => {
+    let url = `https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/${type}.7z`
+    console.log(url)
+    return await tc.downloadTool(url)
+  })
+
+  await common.measure(`Extracting ${type} build tools`, async () =>
+    // -aoa overwrite existing, -bd disable progress indicator
+    exec.exec('7z', ['x', downloadPath, '-aoa', '-bd', '-oC:\\msys64'], { silent: true }))
+}
+
+// Actions windows-2022 image does not contain any MSYS2 build tools.  Install tools for it.
+// A subset of the MSYS2 base-devel group
+async function installMSY2Tools() {
+  const downloadPath = await common.measure(`Download msys2 build tools`, async () => {
+    let url = `https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/msys2.7z`
+    console.log(url)
+    return await tc.downloadTool(url)
+  })
+
+  await common.measure(`Extracting msys2 build tools`, async () =>
+    // -aoa overwrite existing, -bd disable progress indicator
+    exec.exec('7z', ['x', downloadPath, '-aoa', '-bd', '-oC:\\msys64'], { silent: true }))
 }
 
 async function downloadAndExtract(engine, version, url, base, rubyPrefix) {
@@ -68,7 +106,7 @@ async function downloadAndExtract(engine, version, url, base, rubyPrefix) {
   })
 
   await common.measure('Extracting Ruby', async () =>
-    exec.exec('7z', ['x', downloadPath, `-xr!${base}\\share\\doc`, `-o${parentDir}`], { silent: true }))
+    exec.exec('7z', ['x', downloadPath, '-bd', `-xr!${base}\\share\\doc`, `-o${parentDir}`], { silent: true }))
 
   if (base !== path.basename(rubyPrefix)) {
     await io.mv(path.join(parentDir, base), rubyPrefix)

--- a/windows.js
+++ b/windows.js
@@ -22,6 +22,8 @@ const certFile = 'C:\\Program Files\\Git\\mingw64\\ssl\\cert.pem'
 const msys = `${drive}:\\DevKit64`
 const msysPathEntries = [`${msys}\\mingw\\x86_64-w64-mingw32\\bin`, `${msys}\\mingw\\bin`, `${msys}\\bin`]
 
+const virtualEnv = common.getVirtualEnvironmentName()
+
 export function getAvailableVersions(platform, engine) {
   if (engine === 'ruby') {
     return Object.keys(rubyInstallerVersions)
@@ -57,8 +59,6 @@ export async function install(platform, engine, version) {
   }
 
   const winMSYS2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
-
-  const virtualEnv = common.getVirtualEnvironmentName()
 
   if (!['windows-2019', 'windows-2016'].includes(virtualEnv)) {
     await installMSY2Tools()
@@ -175,9 +175,22 @@ async function setupMSWin() {
 /* Sets MSVC environment for use in Actions
  *   allows steps to run without running vcvars*.bat, also for PowerShell
  *   adds a convenience VCVARS environment variable
- *   this assumes a single Visual Studio version being available in the windows-latest image */
+ *   this assumes a single Visual Studio version being available in the window images */
 export function addVCVARSEnv() {
-  const vcVars = '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"'
+  let vcVars = ''
+  switch (virtualEnv) {
+    case 'windows-2016':
+      vcVars = '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"'
+      break
+    case 'windows-2019':
+      vcVars = '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"'
+      break
+    case 'windows-2022':
+      vcVars = '"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"'
+      break
+    default:
+      throw new Error(`Unknown Windows Image: ${virtualEnv}`)
+  }
   core.exportVariable('VCVARS', vcVars)
 
   let newEnv = new Map()

--- a/windows.js
+++ b/windows.js
@@ -77,13 +77,13 @@ export async function install(platform, engine, version) {
 // Actions windows-2022 image does not contain any mingw or ucrt build tools.  Install tools for it,
 // and also install ucrt tools on earlier versions, which have msys2 and mingw tools preinstalled.
 async function installGCCTools(type) {
-  const downloadPath = await common.measure(`Download ${type} build tools`, async () => {
+  const downloadPath = await common.measure(`Downloading ${type} build tools`, async () => {
     let url = `https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/${type}.7z`
     console.log(url)
     return await tc.downloadTool(url)
   })
 
-  await common.measure(`Extracting ${type} build tools`, async () =>
+  await common.measure(`Extracting  ${type} build tools`, async () =>
     // -aoa overwrite existing, -bd disable progress indicator
     exec.exec('7z', ['x', downloadPath, '-aoa', '-bd', '-oC:\\msys64'], { silent: true }))
 }
@@ -91,13 +91,13 @@ async function installGCCTools(type) {
 // Actions windows-2022 image does not contain any MSYS2 build tools.  Install tools for it.
 // A subset of the MSYS2 base-devel group
 async function installMSY2Tools() {
-  const downloadPath = await common.measure(`Download msys2 build tools`, async () => {
+  const downloadPath = await common.measure(`Downloading msys2 build tools`, async () => {
     let url = `https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/msys2.7z`
     console.log(url)
     return await tc.downloadTool(url)
   })
 
-  await common.measure(`Extracting msys2 build tools`, async () =>
+  await common.measure(`Extracting  msys2 build tools`, async () =>
     // -aoa overwrite existing, -bd disable progress indicator
     exec.exec('7z', ['x', downloadPath, '-aoa', '-bd', '-oC:\\msys64'], { silent: true }))
 }
@@ -110,7 +110,7 @@ async function downloadAndExtract(engine, version, url, base, rubyPrefix) {
     return await tc.downloadTool(url)
   })
 
-  await common.measure('Extracting Ruby', async () =>
+  await common.measure('Extracting  Ruby', async () =>
     exec.exec('7z', ['x', downloadPath, '-bd', `-xr!${base}\\share\\doc`, `-o${parentDir}`], { silent: true }))
 
   if (base !== path.basename(rubyPrefix)) {

--- a/windows.js
+++ b/windows.js
@@ -60,11 +60,14 @@ export async function install(platform, engine, version) {
 
   const winMSYS2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
+  // install msys2 tools for all versions, only install mingw or ucrt for Rubies >= 2.4
+
   if (!['windows-2019', 'windows-2016'].includes(virtualEnv)) {
     await installMSY2Tools()
   }
 
-  if (( winMSYS2Type === 'ucrt64') || !['windows-2019', 'windows-2016'].includes(virtualEnv)) {
+  if ((( winMSYS2Type === 'ucrt64') || !['windows-2019', 'windows-2016'].includes(virtualEnv)) &&
+    (common.floatVersion(version) >= 2.4)) {
     await installGCCTools(winMSYS2Type)
   }
 

--- a/windows.js
+++ b/windows.js
@@ -60,7 +60,7 @@ export async function install(platform, engine, version) {
 
   const winMSYS2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
-  // install msys2 tools for all versions, only install mingw or ucrt for Rubies >= 2.4
+  // install msys2 tools for all Ruby versions, only install mingw or ucrt for Rubies >= 2.4
 
   if (!['windows-2019', 'windows-2016'].includes(virtualEnv)) {
     await installMSY2Tools()
@@ -183,7 +183,7 @@ async function setupMSWin() {
 /* Sets MSVC environment for use in Actions
  *   allows steps to run without running vcvars*.bat, also for PowerShell
  *   adds a convenience VCVARS environment variable
- *   this assumes a single Visual Studio version being available in the window images */
+ *   this assumes a single Visual Studio version being available in the Windows images */
 export function addVCVARSEnv() {
   let vcVars = ''
   switch (virtualEnv) {

--- a/windows.js
+++ b/windows.js
@@ -63,7 +63,7 @@ export async function install(platform, engine, version) {
   // install msys2 tools for all Ruby versions, only install mingw or ucrt for Rubies >= 2.4
 
   if (!['windows-2019', 'windows-2016'].includes(virtualEnv)) {
-    await installMSY2Tools()
+    await installMSYS2Tools()
   }
 
   if ((( winMSYS2Type === 'ucrt64') || !['windows-2019', 'windows-2016'].includes(virtualEnv)) &&
@@ -95,7 +95,7 @@ async function installGCCTools(type) {
 
 // Actions windows-2022 image does not contain any MSYS2 build tools.  Install tools for it.
 // A subset of the MSYS2 base-devel group
-async function installMSY2Tools() {
+async function installMSYS2Tools() {
   const downloadPath = await common.measure(`Downloading msys2 build tools`, async () => {
     let url = `https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/msys2.7z`
     console.log(url)
@@ -109,6 +109,13 @@ async function installMSY2Tools() {
   await common.measure(`Extracting  msys2 build tools`, async () =>
     // -aoa overwrite existing, -bd disable progress indicator
     exec.exec('7z', ['x', downloadPath, '-aoa', '-bd', `-o${msys2BasePath}`], { silent: true }))
+}
+
+// Windows JRuby can install gems that require compile tools, only needed for
+// windows-2022 image
+export async function installJRubyTools() {
+  await installMSYS2Tools()
+  await installGCCTools('mingw64')
 }
 
 async function downloadAndExtract(engine, version, url, base, rubyPrefix) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,10 +195,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vercel/ncc@^0.28.6":
-  version "0.28.6"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.28.6.tgz#073c0ce8e0269210c0a9f180fb0bf949eecc20e0"
-  integrity sha512-t4BoSSuyK8BZaUE0gV18V6bkFs4st7baumtFGa50dv1tMu2GDBEBF8sUZaKBdKiL6DzJ2D2+XVCwYWWDcQOYdQ==
+"@vercel/ncc@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.31.1.tgz#9346c7e59326f5eeac75c0286e47df94c2d6d8f7"
+  integrity sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==
 
 abort-controller@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
See commits.  On Windows-2022 image, code adds the MSYS2 packages from 'base-devel' group needed for Ruby builds.

Also adds ENV variables by running `ridk enable`, testing for the file's existence first.  Uses code similar to the code for mswin's vcvars script.  Parses the output of the set command, so it's not dependent on ridk's output.

Windows 2019 Image - No changes when using with a mingw Ruby. When using a ucrt Ruby, a pre-built ucrt 7z file is installed from https://github.com/MSP-Greg/setup-msys2-gcc/releases/tag/msys2-gcc-pkgs.  The 7z files are generated three times a day in that repo.

Windows 2022 Image - Since the image has no MSYS2 build tools installed, both an MSYS2 package and a gcc package (mingw or ucrt) are installed from the MSP-Greg/setup-msys2-gcc repo.