### PR TITLE
Enable `post-ruby-install` hook

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ inputs:
       to invalidate the cache.
     required: false
     default: '0'
+  post-ruby-install:
+    description: |
+      Execute a shell command after installing Ruby but before installing non-default Bundler gem.
+      Ignored if `input.bundler` is set to 'none'.
+    required: false
 outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'


### PR DESCRIPTION
## Motivation

Currently, if one is using this action to set up Ruby and manage caching of their gemset, there is no way to *micro-manage * the environment before Bundler gets installed and consequently executing `bundle install`.

With this hook, the *end-user* will be able to:
- *change* the Rubygems version if needed, or
- install the `rake` gem manually and *invoke Rake task(s)* that sets up the project's Gemfile / Gemspec for consequent consumption by Bundler.

---

P.S. I did not generate the `dist/index.js` because I'm on Windows and the generation process is altering the line-endings.