### PR TITLE
Support Ruby 3.1.0 for Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,12 @@ jobs:
         - { os: windows-2019, ruby: mswin }
         exclude:
         - { os: windows-2016, ruby: 1.9 }
-        - { os: windows-2016, ruby: 3.1 }
         - { os: windows-2016, ruby: debug }
         - { os: windows-2016, ruby: truffleruby }
         - { os: windows-2016, ruby: truffleruby-head }
         - { os: windows-2016, ruby: truffleruby+graalvm }
         - { os: windows-2016, ruby: truffleruby+graalvm-head }
         - { os: windows-2019, ruby: 1.9 }
-        - { os: windows-2019, ruby: 3.1 }
         - { os: windows-2019, ruby: debug }
         - { os: windows-2019, ruby: truffleruby }
         - { os: windows-2019, ruby: truffleruby-head }

--- a/bundler.js
+++ b/bundler.js
@@ -91,7 +91,9 @@ export async function installBundler(bundlerVersionInput, lockFile, platform, ru
   } else {
     const gem = path.join(rubyPrefix, 'bin', 'gem')
     const bundlerVersionConstraint = /^\d+\.\d+\.\d+/.test(bundlerVersion) ? bundlerVersion : `~> ${bundlerVersion}`
-    await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint])
+    // Workaround for https://github.com/rubygems/rubygems/issues/5245
+    const force = (platform.startsWith('windows-') && engine === 'ruby' && common.floatVersion(rubyVersion) >= 3.1) ? ['--force'] : []
+    await exec.exec(gem, ['install', 'bundler', ...force, '-v', bundlerVersionConstraint])
   }
 
   return bundlerVersion

--- a/dist/index.js
+++ b/dist/index.js
@@ -58992,6 +58992,7 @@ const versions = {
   "3.0.1": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.1-1/rubyinstaller-3.0.1-1-x64.7z",
   "3.0.2": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.2-1/rubyinstaller-3.0.2-1-x64.7z",
   "3.0.3": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.3-1/rubyinstaller-3.0.3-1-x64.7z",
+  "3.1.0": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.0-1/rubyinstaller-3.1.0-1-x64.7z",
   "head": "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z",
   "mingw": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z",
   "mswin": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z"

--- a/dist/index.js
+++ b/dist/index.js
@@ -105,7 +105,9 @@ async function installBundler(bundlerVersionInput, lockFile, platform, rubyPrefi
   } else {
     const gem = path.join(rubyPrefix, 'bin', 'gem')
     const bundlerVersionConstraint = /^\d+\.\d+\.\d+/.test(bundlerVersion) ? bundlerVersion : `~> ${bundlerVersion}`
-    await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint])
+    // Workaround for https://github.com/rubygems/rubygems/issues/5245
+    const force = (platform.startsWith('windows-') && engine === 'ruby' && common.floatVersion(rubyVersion) >= 3.1) ? ['--force'] : []
+    await exec.exec(gem, ['install', 'bundler', ...force, '-v', bundlerVersionConstraint])
   }
 
   return bundlerVersion

--- a/windows-versions.js
+++ b/windows-versions.js
@@ -42,6 +42,7 @@ export const versions = {
   "3.0.1": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.1-1/rubyinstaller-3.0.1-1-x64.7z",
   "3.0.2": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.2-1/rubyinstaller-3.0.2-1-x64.7z",
   "3.0.3": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.3-1/rubyinstaller-3.0.3-1-x64.7z",
+  "3.1.0": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.0-1/rubyinstaller-3.1.0-1-x64.7z",
   "head": "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z",
   "mingw": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mingw.7z",
   "mswin": "https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-mswin.7z"


### PR DESCRIPTION
Follow up to https://github.com/oneclick/rubyinstaller2/issues/255#issuecomment-1003266597.

This PR adds Ruby 3.1.0 to windows-version.js.