### PR TITLE
Gemfile - add Rack and RDoc for testing - failures with Ruby 2.4 & 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 
 gem "rake"
 gem "path"
+gem "rdoc"
 gem "json", "2.2.0"
+gem "rack"
+


### PR DESCRIPTION
This seems to intermittently fail.  The RubyGems that ships with Ruby 2.4 and 2.5 is not compatible with the Psych version that can be installed.

RDoc has a dependency on Psych.  Rack is added just so `bundle install --jobs 4` probably needs to run a job after Psych is installed.

This is the weird failure that I spoke of, which is why I had `gem update --system` in the PR.