### PR TITLE
Remove ubuntu-16.04 from the list of supported Ubuntu versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The action works for all [GitHub-hosted runners](https://help.github.com/en/acti
 
 | Operating System | Recommended | Other Supported Versions |
 | ----------- | -------- | -------- |
-| Ubuntu  | `ubuntu-latest`  (= `ubuntu-20.04`) | `ubuntu-18.04`, `ubuntu-16.04` |
+| Ubuntu  | `ubuntu-latest`  (= `ubuntu-20.04`) | `ubuntu-18.04` |
 | macOS   | `macos-latest`   (= `macos-10.15`)  | `macos-11.0` |
 | Windows | `windows-latest` (= `windows-2019`) | `windows-2022` |
 


### PR DESCRIPTION
ubuntu-16.04 is no longer supported as noted on https://github.com/ruby/setup-ruby/issues/221 .
Readme should no longer list ubuntu-16.04 on the supported Ubuntu versions note.