### PR TITLE
add `libgmp` to requirements for self-hosted runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ if the [virtual environment](https://github.com/actions/virtual-environments) is
 * Make sure to use the same operating system and version.
 * Set the environment variable `ImageOS` on the runner to the corresponding value on GitHub-hosted runners (e.g. `ubuntu18`/`macos1015`/`win19`). This is necessary to detect the operating system and version.
 * Make sure to use the same version of libssl.
-* Make sure that the operating system has `libyaml-0` installed
+* Make sure that the operating system has `libyaml-0` and [`libgmp`](https://stackoverflow.com/questions/26555902/ruby-v-dyld-library-not-loaded-usr-local-lib-libgmp-10-dylib) installed
 * The default tool cache directory (`/opt/hostedtoolcache` on Linux, `/Users/runner/hostedtoolcache` on macOS,
   `C:/hostedtoolcache/windows` on Windows) must be writable by the `runner` user.
   This is necessary since the Ruby builds embed the install path when built and cannot be moved around.


### PR DESCRIPTION
Fixes #313.