### PR TITLE
Clarify reference to a known issue now fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ It is recommended to first get your build working on Ubuntu and macOS before try
 * The `PATH` contains [multiple compiler toolchains](https://github.com/ruby/setup-ruby/issues/19). Use `where.exe` to debug which tool is used.
 * For Ruby ≥ 2.4, MSYS2 is prepended to the `Path`, similar to what RubyInstaller2 does.
 * For Ruby < 2.4, the DevKit MSYS tools are installed and prepended to the `Path`.
-* JRuby on Windows has a known bug that `bundle exec rake` [fails](https://github.com/ruby/setup-ruby/issues/18).
+* Use JRuby 9.2.20+ on Windows (older versions have [bugs](https://github.com/ruby/setup-ruby/issues/18#issuecomment-889072695)).
 
 ## Versioning
 


### PR DESCRIPTION
The culprit ended up being https://github.com/jruby/jruby/issues/6745, which was released with JRuby 9.2.20.0.

Happy to change the wording to make this clear instead of removing the reference.