### PR TITLE
Update Node.js from v12 to v16

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 12.0.0
+nodejs 16.0.0
 ruby 2.7.0

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
According to the release policy of Node.js,
Node.js v12 reached EOL (end-of-life).

https://nodejs.org/en/about/releases/

I think ruby/setup-ruby is ready to update Node.js to v16
because GitHub Actions runners support v16.

https://github.com/actions/runner/issues/772