### PR TITLE
Allow usage on macOS 12 runners

### DIFF
--- a/common.js
+++ b/common.js
@@ -104,6 +104,7 @@ export const supportedPlatforms = [
   'ubuntu-22.04',
   'macos-10.15',
   'macos-11.0',
+  'macos-12.0',
   'windows-2019',
   'windows-2022',
 ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -373,6 +373,7 @@ const supportedPlatforms = [
   'ubuntu-22.04',
   'macos-10.15',
   'macos-11.0',
+  'macos-12.0',
   'windows-2019',
   'windows-2022',
 ]


### PR DESCRIPTION
Per my question in #337 I went ahead and tested simply adding macos-12 to the supported platforms, and I had no issues.

Not sure what remaining testing may be needed, but it would appear it "just works"