### PR TITLE
Change pre-commit shebang to `/bin/sh`

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 set -e
 
 if git diff --cached --name-only | grep -E '.(js|json)$'; then


### PR DESCRIPTION
It says it is recommended to copy the pre-commit to our local pre-commit when committing to this repository.
https://github.com/ruby/setup-ruby/blob/master/CONTRIBUTING.md
> It is recommended to add this as a git pre-commit hook:
> ```
> $ cp pre-commit .git/hooks/pre-commit
> ```

When we do this on our macOS environment, we get `No such file or directory` as follows.
```bash 
❯ git commit
fatal: cannot run .git/hooks/pre-commit: No such file or directory
```

The above error is likely because `/usr/bin/sh` is not supposed to exist on macOS.
(Linux may possibly have `/usr/bin/sh`.)

Since it seems redundant for someone to edit pre-commit for every contribution in a macOS environment, we suggest using `/bin/sh` for shebang so that it can be used without editing pre-commit in the macOS environment.

