### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ and the [condition and expression syntax](https://help.github.com/en/actions/ref
 * engine-version like `ruby-2.6.5` and `truffleruby-19.3.0`
 * short version like `'2.6'`, automatically using the latest release matching that version (`2.6.10`)
 * version only like `'2.6.5'`, assumes MRI for the engine
-* engine only like `truffleruby`, uses the latest stable release of that implementation
+* engine only like `ruby` and `truffleruby`, uses the latest stable release of that implementation
 * `.ruby-version` reads from the project's `.ruby-version` file
 * `.tool-versions` reads from the project's `.tool-versions` file
 * If the `ruby-version` input is not specified, `.ruby-version` is tried first, followed by `.tool-versions`


### PR DESCRIPTION
Hi setup-ruby maintainers!

> Added example of using the latest stable version of ruby
> Related to #364

When creating documentation or using other Ruby tools, you may want to specify the latest stable version of CRuby. In such cases, you can specify `ruby-version` with `ruby`, but it can be a little difficult to find this information from the README. Therefore, I thought it would be helpful to provide an example of how to specify ruby in the README, to make it easier to find the method you are looking for. I myself found this solution by searching for "latest stable ruby" in the issues, not from the README. Thank you for always maintaining setup-ruby. Best regards.
