### PR TITLE
ubuntu-latest is now 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The action works on these [GitHub-hosted runners](https://help.github.com/en/act
 
 | Operating System | Recommended | Other Supported Versions |
 | ---------------- | ----------- | ------------------------ |
-| Ubuntu  | `ubuntu-latest` (= `ubuntu-20.04`)  | `ubuntu-18.04`, `ubuntu-22.04` |
+| Ubuntu  | `ubuntu-latest` (= `ubuntu-22.04`)  | `ubuntu-18.04`, `ubuntu-20.04` |
 | macOS   | `macos-latest` (= `macos-11`)       | `macos-10.15`, `macos-12` |
 | Windows | `windows-latest` (= `windows-2022`) | `windows-2019` |
 


### PR DESCRIPTION
According to GitHub Blog ubuntu-latest is now 22.04.

see: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/