### PR TITLE
Bundler higher than ~> 2.4.0 will require Ruby 3.0 or later

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -108,6 +108,7 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
 
   // Use Bundler 1 when we know Bundler 2 does not work
   // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
+  // Use Bundler 2.4 when we use Ruby 2.6-2.7
   if (bundlerVersion.startsWith('2')) {
     if (engine === 'ruby' && floatVersion <= 2.2) {
       console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
@@ -118,6 +119,9 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
     } else if (engine === 'ruby' && floatVersion <= 2.5) {
       console.log('Ruby 2.3.2-2.5 only works with Bundler 2.3')
       bundlerVersion = '2.3'
+    } else if (engine === 'ruby' && floatVersion <= 2.7) {
+      console.log('Ruby 2.6-2.7 only works with Bundler 2.4')
+      bundlerVersion = '2.4'
     } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
       console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
       bundlerVersion = '1'

--- a/bundler.js
+++ b/bundler.js
@@ -107,8 +107,6 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
   }
 
   // Use Bundler 1 when we know Bundler 2 does not work
-  // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
-  // Use Bundler 2.4 when we use Ruby 2.6-2.7
   if (bundlerVersion.startsWith('2')) {
     if (engine === 'ruby' && floatVersion <= 2.2) {
       console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
@@ -116,15 +114,21 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
     } else if (engine === 'ruby' && /^2\.3\.[01]/.test(rubyVersion)) {
       console.log('Ruby 2.3.0 and 2.3.1 have shipped with an old rubygems that only works with Bundler 1')
       bundlerVersion = '1'
-    } else if (engine === 'ruby' && floatVersion <= 2.5) {
+    } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
+      console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
+      bundlerVersion = '1'
+    }
+  }
+
+  // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
+  // Use Bundler 2.4 when we use Ruby 2.6-2.7
+  if (bundlerVersion == '2') {
+    if (engine === 'ruby' && floatVersion <= 2.5) {
       console.log('Ruby 2.3.2-2.5 only works with Bundler 2.3')
       bundlerVersion = '2.3'
     } else if (engine === 'ruby' && floatVersion <= 2.7) {
       console.log('Ruby 2.6-2.7 only works with Bundler 2.4')
       bundlerVersion = '2.4'
-    } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
-      console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
-      bundlerVersion = '1'
     }
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -122,8 +122,6 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
   }
 
   // Use Bundler 1 when we know Bundler 2 does not work
-  // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
-  // Use Bundler 2.4 when we use Ruby 2.6-2.7
   if (bundlerVersion.startsWith('2')) {
     if (engine === 'ruby' && floatVersion <= 2.2) {
       console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
@@ -131,15 +129,21 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
     } else if (engine === 'ruby' && /^2\.3\.[01]/.test(rubyVersion)) {
       console.log('Ruby 2.3.0 and 2.3.1 have shipped with an old rubygems that only works with Bundler 1')
       bundlerVersion = '1'
-    } else if (engine === 'ruby' && floatVersion <= 2.5) {
+    } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
+      console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
+      bundlerVersion = '1'
+    }
+  }
+
+  // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
+  // Use Bundler 2.4 when we use Ruby 2.6-2.7
+  if (bundlerVersion == '2') {
+    if (engine === 'ruby' && floatVersion <= 2.5) {
       console.log('Ruby 2.3.2-2.5 only works with Bundler 2.3')
       bundlerVersion = '2.3'
     } else if (engine === 'ruby' && floatVersion <= 2.7) {
       console.log('Ruby 2.6-2.7 only works with Bundler 2.4')
       bundlerVersion = '2.4'
-    } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
-      console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
-      bundlerVersion = '1'
     }
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -123,6 +123,7 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
 
   // Use Bundler 1 when we know Bundler 2 does not work
   // Use Bundler 2.3 when we use Ruby 2.3.2-2.5
+  // Use Bundler 2.4 when we use Ruby 2.6-2.7
   if (bundlerVersion.startsWith('2')) {
     if (engine === 'ruby' && floatVersion <= 2.2) {
       console.log('Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2')
@@ -133,6 +134,9 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
     } else if (engine === 'ruby' && floatVersion <= 2.5) {
       console.log('Ruby 2.3.2-2.5 only works with Bundler 2.3')
       bundlerVersion = '2.3'
+    } else if (engine === 'ruby' && floatVersion <= 2.7) {
+      console.log('Ruby 2.6-2.7 only works with Bundler 2.4')
+      bundlerVersion = '2.4'
     } else if (engine === 'jruby' && rubyVersion.startsWith('9.1')) { // JRuby 9.1 targets Ruby 2.3, treat it the same
       console.log('JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 instead on JRuby 9.1')
       bundlerVersion = '1'


### PR DESCRIPTION
This is so that I don't forget to do this before next year's Bundler release.

I also fixed a small bug introduced with #423 where an explicit and valid input configured by users like `bundler: 2.2` would be ignored and "bundler: 2.3" would be installed instead.