### PR TITLE
Consider a different $RUNNER_TOOL_CACHE than the default as a self-hosted runner and add self-hosted input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ inputs:
     description: |
       Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need
       to invalidate the cache.
+  self-hosted:
+    description: |
+      Consider the runner as a self-hosted runner, which means not using prebuilt Ruby binaries which only work
+      on GitHub-hosted runners or self-hosted runners with a very similar image to the ones used by GitHub runners.
+      The default is to detect this automatically based on the OS, OS version and $RUNNER_TOOL_CACHE.
 outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'

--- a/common.js
+++ b/common.js
@@ -13,6 +13,10 @@ export const windows = (os.platform() === 'win32')
 // Extract to SSD on Windows, see https://github.com/ruby/setup-ruby/pull/14
 export const drive = (windows ? (process.env['GITHUB_WORKSPACE'] || 'C')[0] : undefined)
 
+export const inputs = {
+  selfHosted: undefined
+}
+
 export function partition(string, separator) {
   const i = string.indexOf(separator)
   if (i === -1) {
@@ -166,8 +170,13 @@ const GitHubHostedPlatforms = [
 // * the OS and OS version does not correspond to a GitHub-hosted runner image,
 // * or the hosted tool cache is different from the default tool cache path
 export function isSelfHostedRunner() {
-  return !GitHubHostedPlatforms.includes(getOSNameVersionArch()) ||
-      getRunnerToolCache() !== getDefaultToolCachePath()
+  if (inputs.selfHosted === undefined) {
+    throw new Error('inputs.selfHosted should have been already set')
+  }
+
+  return inputs.selfHosted === 'true' ||
+    !GitHubHostedPlatforms.includes(getOSNameVersionArch()) ||
+    getRunnerToolCache() !== getDefaultToolCachePath()
 }
 
 let virtualEnvironmentName = undefined

--- a/common.js
+++ b/common.js
@@ -179,6 +179,18 @@ export function isSelfHostedRunner() {
     getRunnerToolCache() !== getDefaultToolCachePath()
 }
 
+export function selfHostedRunnerReason() {
+  if (inputs.selfHosted === 'true') {
+    return 'the self-hosted input was set'
+  } else if (!GitHubHostedPlatforms.includes(getOSNameVersionArch())) {
+    return 'the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported)'
+  } else if (getRunnerToolCache() !== getDefaultToolCachePath()) {
+    return 'the $RUNNER_TOOL_CACHE is different than the default tool cache path (they must be the same to reuse prebuilt Ruby binaries)'
+  } else {
+    return 'unknown reason'
+  }
+}
+
 let virtualEnvironmentName = undefined
 
 export function getVirtualEnvironmentName() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -305,6 +305,7 @@ __nccwpck_require__.d(__webpack_exports__, {
   "isStableVersion": () => (/* binding */ isStableVersion),
   "measure": () => (/* binding */ measure),
   "partition": () => (/* binding */ partition),
+  "selfHostedRunnerReason": () => (/* binding */ selfHostedRunnerReason),
   "setupPath": () => (/* binding */ setupPath),
   "shouldUseToolCache": () => (/* binding */ shouldUseToolCache),
   "targetRubyVersion": () => (/* binding */ targetRubyVersion),
@@ -531,6 +532,18 @@ function isSelfHostedRunner() {
   return inputs.selfHosted === 'true' ||
     !GitHubHostedPlatforms.includes(getOSNameVersionArch()) ||
     getRunnerToolCache() !== getDefaultToolCachePath()
+}
+
+function selfHostedRunnerReason() {
+  if (inputs.selfHosted === 'true') {
+    return 'the self-hosted input was set'
+  } else if (!GitHubHostedPlatforms.includes(getOSNameVersionArch())) {
+    return 'the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported)'
+  } else if (getRunnerToolCache() !== getDefaultToolCachePath()) {
+    return 'the $RUNNER_TOOL_CACHE is different than the default tool cache path (they must be the same to reuse prebuilt Ruby binaries)'
+  } else {
+    return 'unknown reason'
+  }
 }
 
 let virtualEnvironmentName = undefined
@@ -68270,8 +68283,8 @@ async function install(platform, engine, version) {
       if (common.isSelfHostedRunner()) {
         const rubyBuildDefinition = engine === 'ruby' ? version : `${engine}-${version}`
         core.error(
-          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted and not matching a GitHub-hosted runner image.\n` +
-          `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build:\n` +
+          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted because ${common.selfHostedRunnerReason()}.\n` +
+          `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build\n` +
           `You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml\n` +
           `$ ruby-build ${rubyBuildDefinition} ${toolCacheRubyPrefix}\n` +
           `Once that completes successfully, mark it as complete with:\n` +

--- a/dist/index.js
+++ b/dist/index.js
@@ -296,6 +296,7 @@ __nccwpck_require__.d(__webpack_exports__, {
   "getVirtualEnvironmentName": () => (/* binding */ getVirtualEnvironmentName),
   "hasBundlerDefaultGem": () => (/* binding */ hasBundlerDefaultGem),
   "hashFile": () => (/* binding */ hashFile),
+  "inputs": () => (/* binding */ inputs),
   "isBundler1Default": () => (/* binding */ isBundler1Default),
   "isBundler2Default": () => (/* binding */ isBundler2Default),
   "isBundler2dot2Default": () => (/* binding */ isBundler2dot2Default),
@@ -365,6 +366,10 @@ const linuxOSInfo = __nccwpck_require__(8487)
 const windows = (os.platform() === 'win32')
 // Extract to SSD on Windows, see https://github.com/ruby/setup-ruby/pull/14
 const drive = (windows ? (process.env['GITHUB_WORKSPACE'] || 'C')[0] : undefined)
+
+const inputs = {
+  selfHosted: undefined
+}
 
 function partition(string, separator) {
   const i = string.indexOf(separator)
@@ -519,8 +524,13 @@ const GitHubHostedPlatforms = [
 // * the OS and OS version does not correspond to a GitHub-hosted runner image,
 // * or the hosted tool cache is different from the default tool cache path
 function isSelfHostedRunner() {
-  return !GitHubHostedPlatforms.includes(getOSNameVersionArch()) ||
-      getRunnerToolCache() !== getDefaultToolCachePath()
+  if (inputs.selfHosted === undefined) {
+    throw new Error('inputs.selfHosted should have been already set')
+  }
+
+  return inputs.selfHosted === 'true' ||
+    !GitHubHostedPlatforms.includes(getOSNameVersionArch()) ||
+    getRunnerToolCache() !== getDefaultToolCachePath()
 }
 
 let virtualEnvironmentName = undefined
@@ -69022,6 +69032,7 @@ const inputDefaults = {
   'bundler-cache': 'false',
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
+  'self-hosted': 'false',
 }
 
 // entry point when this action is run on its own
@@ -69045,6 +69056,7 @@ async function setupRuby(options = {}) {
       inputs[key] = core.getInput(key) || inputDefaults[key]
     }
   }
+  common.inputs.selfHosted = inputs['self-hosted']
 
   process.chdir(inputs['working-directory'])
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const inputDefaults = {
   'bundler-cache': 'false',
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
+  'self-hosted': 'false',
 }
 
 // entry point when this action is run on its own
@@ -39,6 +40,7 @@ export async function setupRuby(options = {}) {
       inputs[key] = core.getInput(key) || inputDefaults[key]
     }
   }
+  common.inputs.selfHosted = inputs['self-hosted']
 
   process.chdir(inputs['working-directory'])
 

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -28,8 +28,8 @@ export async function install(platform, engine, version) {
       if (common.isSelfHostedRunner()) {
         const rubyBuildDefinition = engine === 'ruby' ? version : `${engine}-${version}`
         core.error(
-          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted and not matching a GitHub-hosted runner image.\n` +
-          `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build:\n` +
+          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted because ${common.selfHostedRunnerReason()}.\n` +
+          `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build\n` +
           `You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml\n` +
           `$ ruby-build ${rubyBuildDefinition} ${toolCacheRubyPrefix}\n` +
           `Once that completes successfully, mark it as complete with:\n` +

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -28,7 +28,7 @@ export async function install(platform, engine, version) {
       if (common.isSelfHostedRunner()) {
         const rubyBuildDefinition = engine === 'ruby' ? version : `${engine}-${version}`
         core.error(
-          `The current runner (${common.getOSNameVersionArch()}) was detected as self-hosted and not matching a GitHub-hosted runner image.\n` +
+          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted and not matching a GitHub-hosted runner image.\n` +
           `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build:\n` +
           `You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml\n` +
           `$ ruby-build ${rubyBuildDefinition} ${toolCacheRubyPrefix}\n` +


### PR DESCRIPTION
Fixes https://github.com/ruby/setup-ruby/issues/242