### PR TITLE
Use the default tool cache path on self-hosted runners matching a GH-hosted runner image

### DIFF
--- a/common.js
+++ b/common.js
@@ -264,15 +264,18 @@ function getDefaultToolCachePath() {
   }
 }
 
-export function getToolCacheRubyPrefix(platform, engine, version) {
-  const toolCache = getToolCachePath()
-  const name = {
+export function engineToToolCacheName(engine) {
+  return {
     ruby: 'Ruby',
     jruby: 'JRuby',
     truffleruby: 'TruffleRuby',
     "truffleruby+graalvm": 'TruffleRubyGraalVM'
   }[engine]
-  return path.join(toolCache, name, version, os.arch())
+}
+
+export function getToolCacheRubyPrefix(platform, engine, version) {
+  const toolCache = getToolCachePath()
+  return path.join(toolCache, engineToToolCacheName(engine), version, os.arch())
 }
 
 export function toolCacheCompleteFile(toolCacheRubyPrefix) {

--- a/common.js
+++ b/common.js
@@ -5,6 +5,7 @@ const util = require('util')
 const stream = require('stream')
 const crypto = require('crypto')
 const core = require('@actions/core')
+const tc = require('@actions/tool-cache')
 const { performance } = require('perf_hooks')
 const linuxOSInfo = require('linux-os-info')
 import macosRelease from 'macos-release'
@@ -264,7 +265,18 @@ function getDefaultToolCachePath() {
   }
 }
 
-export function engineToToolCacheName(engine) {
+// tc.find() but using RUNNER_TOOL_CACHE=getToolCachePath()
+export function toolCacheFind(engine, version) {
+  const originalToolCache = getToolCachePath()
+  process.env['RUNNER_TOOL_CACHE'] = getToolCachePath()
+  try {
+    return tc.find(engineToToolCacheName(engine), version)
+  } finally {
+    process.env['RUNNER_TOOL_CACHE'] = originalToolCache
+  }
+}
+
+function engineToToolCacheName(engine) {
   return {
     ruby: 'Ruby',
     jruby: 'JRuby',

--- a/dist/index.js
+++ b/dist/index.js
@@ -289,7 +289,6 @@ __nccwpck_require__.r(__webpack_exports__);
 __nccwpck_require__.d(__webpack_exports__, {
   "createToolCacheCompleteFile": () => (/* binding */ createToolCacheCompleteFile),
   "drive": () => (/* binding */ drive),
-  "engineToToolCacheName": () => (/* binding */ engineToToolCacheName),
   "floatVersion": () => (/* binding */ floatVersion),
   "getOSNameVersionArch": () => (/* binding */ getOSNameVersionArch),
   "getRunnerToolCache": () => (/* binding */ getRunnerToolCache),
@@ -313,6 +312,7 @@ __nccwpck_require__.d(__webpack_exports__, {
   "targetRubyVersion": () => (/* binding */ targetRubyVersion),
   "time": () => (/* binding */ time),
   "toolCacheCompleteFile": () => (/* binding */ toolCacheCompleteFile),
+  "toolCacheFind": () => (/* binding */ toolCacheFind),
   "win2nix": () => (/* binding */ win2nix),
   "windows": () => (/* binding */ windows)
 });
@@ -362,6 +362,7 @@ const util = __nccwpck_require__(3837)
 const stream = __nccwpck_require__(2781)
 const common_crypto = __nccwpck_require__(6113)
 const core = __nccwpck_require__(2186)
+const tc = __nccwpck_require__(7784)
 const { performance } = __nccwpck_require__(4074)
 const linuxOSInfo = __nccwpck_require__(8487)
 ;
@@ -618,6 +619,17 @@ function getDefaultToolCachePath() {
     return 'C:\\hostedtoolcache\\windows'
   } else {
     throw new Error('Unknown platform')
+  }
+}
+
+// tc.find() but using RUNNER_TOOL_CACHE=getToolCachePath()
+function toolCacheFind(engine, version) {
+  const originalToolCache = getToolCachePath()
+  process.env['RUNNER_TOOL_CACHE'] = getToolCachePath()
+  try {
+    return tc.find(engineToToolCacheName(engine), version)
+  } finally {
+    process.env['RUNNER_TOOL_CACHE'] = originalToolCache
   }
 }
 
@@ -68284,7 +68296,7 @@ function getAvailableVersions(platform, engine) {
 async function install(platform, engine, version) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
+    inToolCache = common.toolCacheFind(engine, version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {
@@ -68498,7 +68510,7 @@ async function install(platform, engine, version) {
 
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
+    inToolCache = common.toolCacheFind(engine, version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -289,6 +289,7 @@ __nccwpck_require__.r(__webpack_exports__);
 __nccwpck_require__.d(__webpack_exports__, {
   "createToolCacheCompleteFile": () => (/* binding */ createToolCacheCompleteFile),
   "drive": () => (/* binding */ drive),
+  "engineToToolCacheName": () => (/* binding */ engineToToolCacheName),
   "floatVersion": () => (/* binding */ floatVersion),
   "getOSNameVersionArch": () => (/* binding */ getOSNameVersionArch),
   "getRunnerToolCache": () => (/* binding */ getRunnerToolCache),
@@ -620,15 +621,18 @@ function getDefaultToolCachePath() {
   }
 }
 
-function getToolCacheRubyPrefix(platform, engine, version) {
-  const toolCache = getToolCachePath()
-  const name = {
+function engineToToolCacheName(engine) {
+  return {
     ruby: 'Ruby',
     jruby: 'JRuby',
     truffleruby: 'TruffleRuby',
     "truffleruby+graalvm": 'TruffleRubyGraalVM'
   }[engine]
-  return path.join(toolCache, name, version, os.arch())
+}
+
+function getToolCacheRubyPrefix(platform, engine, version) {
+  const toolCache = getToolCachePath()
+  return path.join(toolCache, engineToToolCacheName(engine), version, os.arch())
 }
 
 function toolCacheCompleteFile(toolCacheRubyPrefix) {
@@ -68280,7 +68284,7 @@ function getAvailableVersions(platform, engine) {
 async function install(platform, engine, version) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find('Ruby', version)
+    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {
@@ -68494,7 +68498,7 @@ async function install(platform, engine, version) {
 
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find('Ruby', version)
+    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -20,7 +20,7 @@ export function getAvailableVersions(platform, engine) {
 export async function install(platform, engine, version) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find('Ruby', version)
+    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -28,7 +28,7 @@ export async function install(platform, engine, version) {
       if (common.isSelfHostedRunner()) {
         const rubyBuildDefinition = engine === 'ruby' ? version : `${engine}-${version}`
         core.error(
-          `The current runner (${common.getOSNameVersionArch()}, RUNNER_TOOL_CACHE=${common.getRunnerToolCache()}) was detected as self-hosted because ${common.selfHostedRunnerReason()}.\n` +
+          `The current runner (${common.getOSNameVersionArch()}) was detected as self-hosted because ${common.selfHostedRunnerReason()}.\n` +
           `In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build\n` +
           `You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml\n` +
           `$ ruby-build ${rubyBuildDefinition} ${toolCacheRubyPrefix}\n` +

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -20,7 +20,7 @@ export function getAvailableVersions(platform, engine) {
 export async function install(platform, engine, version) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
+    inToolCache = common.toolCacheFind(engine, version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {

--- a/windows.js
+++ b/windows.js
@@ -49,7 +49,7 @@ export async function install(platform, engine, version) {
 
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
+    inToolCache = common.toolCacheFind(engine, version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {

--- a/windows.js
+++ b/windows.js
@@ -49,7 +49,7 @@ export async function install(platform, engine, version) {
 
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
-    inToolCache = tc.find('Ruby', version)
+    inToolCache = tc.find(common.engineToToolCacheName(engine), version)
     if (inToolCache) {
       rubyPrefix = inToolCache
     } else {


### PR DESCRIPTION
Fixes #475 