### PR TITLE
Explicitly exit after this action runs to not wait for hanging promises

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65727,6 +65727,9 @@ async function run() {
       core.setFailed(error.stack)
     }
   }
+  // Explicit process.exit() to not wait hanging promises,
+  // see https://github.com/ruby/setup-ruby/issues/543
+  process.exit()
 }
 
 // entry point when this action is run from other actions

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ export async function run() {
       core.setFailed(error.stack)
     }
   }
+  // Explicit process.exit() to not wait hanging promises,
+  // see https://github.com/ruby/setup-ruby/issues/543
+  process.exit()
 }
 
 // entry point when this action is run from other actions


### PR DESCRIPTION
* See https://github.com/ruby/setup-ruby/issues/543