### PR TITLE
Support bundler-only runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
           '1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', ruby-head,
           jruby, jruby-head,
           truffleruby, truffleruby-head,
-          truffleruby+graalvm, truffleruby+graalvm-head
+          truffleruby+graalvm, truffleruby+graalvm-head,
+          system
         ]
         include:
         - { os: windows-2019, ruby: mingw }
@@ -56,6 +57,7 @@ jobs:
         - { os: windows-2022, ruby: truffleruby-head }
         - { os: windows-2022, ruby: truffleruby+graalvm }
         - { os: windows-2022, ruby: truffleruby+graalvm-head }
+        - { os: windows-2022, ruby: system }
 
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -63,6 +65,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: ./
+      id: setup-ruby
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -72,6 +75,8 @@ jobs:
       run: |
         # Show PATH with Powershell
         $f, $r = $env:PATH.split([IO.Path]::PathSeparator); $r
+    - name: Ruby prefix output
+      run: echo "${{ steps.setup-ruby.outputs.ruby-prefix }}"
 
     - name: build compiler
       run: |
@@ -107,6 +112,7 @@ jobs:
 
     - run: gem env
     - name: C extension test
+      if: matrix.ruby != 'system'
       run: gem install json -v 2.2.0
     - run: bundle --version
     # This step is redundant with `bundler-cache: true` but is there to check a redundant `bundle install` still works
@@ -129,6 +135,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
 
     - name: Test `gem github:` in a Gemfile
+      if: matrix.ruby != 'system' || !startsWith(matrix.os, 'ubuntu')
       run: bundle install
       env:
         BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/gem_from_github.gemfile

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,10 @@ branding:
   icon: download
 inputs:
   ruby-version:
-    description: 'Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset.'
+    description: |
+      Engine and version to use. Either 'default' (the default), 'system', or a engine/version syntax described in the README.
+      For 'default', reads from .ruby-version or .tool-versions.
+      For 'system', don't install any Ruby and use the first available Ruby on the PATH.
     default: 'default'
   rubygems:
     description: |

--- a/index.js
+++ b/index.js
@@ -48,17 +48,22 @@ export async function setupRuby(options = {}) {
   process.chdir(inputs['working-directory'])
 
   const platform = common.getOSNameVersion()
-  const [engine, parsedVersion] = parseRubyEngineAndVersion(inputs['ruby-version'])
+  const [engine, parsedVersion] = await parseRubyEngineAndVersion(inputs['ruby-version'])
+  const systemRuby = inputs['ruby-version'] === 'system'
 
-  let installer
-  if (platform.startsWith('windows-') && engine === 'ruby' && !common.isSelfHostedRunner()) {
-    installer = require('./windows')
+  let installer, version
+  if (systemRuby) {
+    version = parsedVersion
   } else {
-    installer = require('./ruby-builder')
-  }
+    if (platform.startsWith('windows-') && engine === 'ruby' && !common.isSelfHostedRunner()) {
+      installer = require('./windows')
+    } else {
+      installer = require('./ruby-builder')
+    }
 
-  const engineVersions = installer.getAvailableVersions(platform, engine)
-  const version = validateRubyEngineAndVersion(platform, engineVersions, engine, parsedVersion)
+    const engineVersions = installer.getAvailableVersions(platform, engine)
+    version = validateRubyEngineAndVersion(platform, engineVersions, engine, parsedVersion)
+  }
 
   createGemRC(engine, version)
   envPreInstall()
@@ -70,7 +75,12 @@ export async function setupRuby(options = {}) {
     await require('./windows').installJRubyTools()
   }
 
-  const rubyPrefix = await installer.install(platform, engine, version)
+  let rubyPrefix
+  if (systemRuby) {
+    rubyPrefix = await getSystemRubyPrefix()
+  } else {
+    rubyPrefix = await installer.install(platform, engine, version)
+  }
 
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))
@@ -93,18 +103,18 @@ export async function setupRuby(options = {}) {
 
   if (inputs['bundler'] !== 'none') {
     bundlerVersion = await common.measure('Installing Bundler', async () =>
-      bundler.installBundler(inputs['bundler'], rubygemsInputSet, lockFile, platform, rubyPrefix, engine, version))
+      bundler.installBundler(inputs['bundler'], rubygemsInputSet, systemRuby, lockFile, platform, rubyPrefix, engine, version))
   }
 
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
-      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
+      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version'], systemRuby))
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)
 }
 
-function parseRubyEngineAndVersion(rubyVersion) {
+async function parseRubyEngineAndVersion(rubyVersion) {
   if (rubyVersion === 'default') {
     if (fs.existsSync('.ruby-version')) {
       rubyVersion = '.ruby-version'
@@ -112,6 +122,17 @@ function parseRubyEngineAndVersion(rubyVersion) {
       rubyVersion = '.tool-versions'
     } else {
       throw new Error('input ruby-version needs to be specified if no .ruby-version or .tool-versions file exists')
+    }
+  } else if (rubyVersion === 'system') {
+    rubyVersion = ''
+    await exec.exec('ruby', ['-e', 'print "#{RUBY_ENGINE}-#{RUBY_VERSION}"'], {
+      silent: true,
+      listeners: {
+        stdout: (data) => (rubyVersion += data.toString())
+      }
+    })
+    if (!rubyVersion.includes('-')) {
+      throw new Error('Could not determine system Ruby engine and version')
     }
   }
 
@@ -189,6 +210,20 @@ function envPreInstall() {
     // bash - needed to maintain Path from Windows
     core.exportVariable('MSYS2_PATH_TYPE', 'inherit')
   }
+}
+
+async function getSystemRubyPrefix() {
+  let rubyPrefix = ''
+  await exec.exec('ruby', ['-rrbconfig', '-e', 'print RbConfig::CONFIG["prefix"]'], {
+    silent: true,
+    listeners: {
+      stdout: (data) => (rubyPrefix += data.toString())
+    }
+  })
+  if (!rubyPrefix) {
+    throw new Error('Could not determine system Ruby prefix')
+  }
+  return rubyPrefix
 }
 
 if (__filename.endsWith('index.js')) { run() }


### PR DESCRIPTION
#489

Seems to work across all macOS and Ubuntu runners.

Cache key has an extra `RUBY_PLATFORM` when using system Ruby as that can vary depending on how Ruby is compiled. For example, on macOS you could have a Ruby compiled for an older Darwin version than the one you are currently running on.