### PR TITLE
Fixup 'rubygems: latest'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,15 +169,25 @@ jobs:
       - run: ruby -v
 
   testLatestRubygemsVersion:
-    name: "Test rubygems: latest upgrades the default RubyGems version"
+    name: "Ruby ${{ matrix.ruby }}: latest upgrades RubyGems"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { ruby: '3.2', expected_rubygems_version: '3.5.3'  }
+        - { ruby: '3.0', expected_rubygems_version: '3.5.3'  }
+        - { ruby: '2.7', expected_rubygems_version: '3.4.22' }
+        - { ruby: '2.6', expected_rubygems_version: '3.4.22' }
+        - { ruby: '2.5', expected_rubygems_version: '3.3.27' }
+        - { ruby: '2.3', expected_rubygems_version: '3.3.27' }
     steps:
     - uses: actions/checkout@v4
     - uses: ./
       with:
-        ruby-version: '2.6'
+        ruby-version: ${{ matrix.ruby }}
         rubygems: latest
-    - run: ruby -e "exit(Gem.rubygems_version > Gem::Version.new('3.0.3'))"
+    - run: ruby -e 'puts Gem::VERSION; exit(Gem.rubygems_version >= Gem::Version.new("${{ matrix.expected_rubygems_version }}"))'
 
   testFixedRubygemsVersionUpgrades:
     name: "Test rubygems: version upgrades RubyGems to that version if the default is older"

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,8 @@ inputs:
     description: |
       The version of RubyGems to use. Either 'default' (the default), 'latest', or a version number (e.g., 3.3.5).
       For 'default', no action is taken and the version of RubyGems that comes with Ruby by default is used.
-      For 'latest', `gem update --system` is run to update to the latest RubyGems version.
+      For 'latest', `gem update --system` is run to update to the latest compatible RubyGems version.
+      Ruby head/master builds and Ruby 2.2 and earlier will not be updated.
       Similarly, if a version number is given, `gem update --system <version>` is run to update to that version of RubyGems, as long as that version is newer than the one provided by default.
   bundler:
     description: |

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export async function setupRuby(options = {}) {
   const rubygemsInputSet = inputs['rubygems'] !== 'default'
   if (rubygemsInputSet) {
     await common.measure('Updating RubyGems', async () =>
-      rubygems.rubygemsUpdate(inputs['rubygems'], rubyPrefix))
+      rubygems.rubygemsUpdate(inputs['rubygems'], rubyPrefix, platform, engine, version))
   }
 
   // When setup-ruby is used by other actions, this allows code in them to run

--- a/rubygems.js
+++ b/rubygems.js
@@ -1,8 +1,9 @@
+const common = require('./common')
 const path = require('path')
 const exec = require('@actions/exec')
 const semver = require('semver')
 
-export async function rubygemsUpdate(rubygemsVersionInput, rubyPrefix) {
+export async function rubygemsUpdate(rubygemsVersionInput, rubyPrefix, platform, engine, version) {
   const gem = path.join(rubyPrefix, 'bin', 'gem')
 
   let gemVersion = ''
@@ -18,7 +19,7 @@ export async function rubygemsUpdate(rubygemsVersionInput, rubyPrefix) {
 
   if (rubygemsVersionInput === 'latest') {
     console.log('Updating RubyGems to latest version')
-    await exec.exec(gem, ['update', '--system'])
+    await rubygemsLatest(gem, platform, engine, version)
   } else if (semver.gt(rubygemsVersionInput, gemVersion)) {
     console.log(`Updating RubyGems to ${rubygemsVersionInput}`)
     await exec.exec(gem, ['update', '--system', rubygemsVersionInput])
@@ -27,4 +28,28 @@ export async function rubygemsUpdate(rubygemsVersionInput, rubyPrefix) {
   }
 
   return true
+}
+
+// Older RubyGems versions do not account for 'required_ruby_version' when
+// running 'gem update --system', so we have to force a compatible version of
+// rubygems-update.  See https://github.com/ruby/setup-ruby/pull/551 and
+// https://github.com/rubygems/rubygems/issues/7329
+async function rubygemsLatest(gem, platform, engine, version) {
+  if (engine === 'ruby') {
+    const rubyFloatVersion = common.floatVersion(version)
+    if (common.isHeadVersion(version)) {
+      console.log('Ruby master builds use included RubyGems')
+    } else if (rubyFloatVersion >= 3.0) {
+      await exec.exec(gem, ['update', '--system'])
+    } else if (rubyFloatVersion >= 2.6) {
+      await exec.exec(gem, ['update', '--system', '3.4.22'])
+    } else if (rubyFloatVersion >= 2.3) {
+      await exec.exec(gem, ['update', '--system', '3.3.27'])
+    } else {
+      console.log(`Cannot update RubyGems for Ruby version ${version}`)
+    }
+  } else {
+    // non MRI Rubies (TruffleRuby and JRuby)
+    await exec.exec(gem, ['update', '--system'])
+  }
 }


### PR DESCRIPTION
Fixes using 'rubygems; latest' for MRI Ruby 2.3 and later.  I tried updating Ruby 2.2 and got errors for two different versions.

`gem update --system` will not allow a bounded version, only an exact version.  So, code is somewhat brittle if new patch releases are done for older RubyGems versions.

Code works same as existing for non MRI Rubies.

One thing I wasn't sure about is whether Ruby master/head builds should not have anything done for 'rubygems; latest'.  Sometime this year I think the RubyGems version was a pre-release, so latest would install an earlier version?  Not.Sure.

Happy Holidays...