### PR TITLE
Add ridk option to disable ridk env variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,8 @@ inputs:
       Consider the runner as a self-hosted runner, which means not using prebuilt Ruby binaries which only work
       on GitHub-hosted runners or self-hosted runners with a very similar image to the ones used by GitHub runners.
       The default is to detect this automatically based on the OS, OS version and architecture.
+  ridk:
+    description: 'By default, ridk environment variables are added for Windows. For "none", nothing is done.'
 outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'

--- a/dist/index.js
+++ b/dist/index.js
@@ -64970,7 +64970,7 @@ function getAvailableVersions(platform, engine) {
   return rubyBuilderVersions[engine]
 }
 
-async function install(platform, engine, version) {
+async function install(platform, engine, version, installOptions) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
     inToolCache = common.toolCacheFind(engine, version)
@@ -65208,7 +65208,7 @@ function getAvailableVersions(platform, engine) {
   }
 }
 
-async function install(platform, engine, version) {
+async function install(platform, engine, version, installOptions) {
   const url = rubyInstallerVersions[version]
 
   // The windows-2016 and windows-2019 images have MSYS2 build tools (C:/msys64/usr)
@@ -65257,7 +65257,7 @@ async function install(platform, engine, version) {
   }
 
   const ridk = `${rubyPrefix}\\bin\\ridk.cmd`
-  if (fs.existsSync(ridk)) {
+  if (fs.existsSync(ridk) && installOptions['ridk'] !== 'none') {
     await common.measure('Adding ridk env variables', async () => addRidkEnv(ridk))
   }
 
@@ -65782,8 +65782,10 @@ async function setupRuby(options = {}) {
   const [engine, parsedVersion] = parseRubyEngineAndVersion(inputs['ruby-version'])
 
   let installer
+  const installOptions = {}
   if (platform.startsWith('windows-') && engine === 'ruby' && !common.isSelfHostedRunner()) {
     installer = __nccwpck_require__(3216)
+    installOptions['ridk'] = inputs['ridk']
   } else {
     installer = __nccwpck_require__(9974)
   }
@@ -65801,7 +65803,7 @@ async function setupRuby(options = {}) {
     await (__nccwpck_require__(3216).installJRubyTools)()
   }
 
-  const rubyPrefix = await installer.install(platform, engine, version)
+  const rubyPrefix = await installer.install(platform, engine, version, installOptions)
 
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))

--- a/index.js
+++ b/index.js
@@ -51,8 +51,10 @@ export async function setupRuby(options = {}) {
   const [engine, parsedVersion] = parseRubyEngineAndVersion(inputs['ruby-version'])
 
   let installer
+  const installOptions = {}
   if (platform.startsWith('windows-') && engine === 'ruby' && !common.isSelfHostedRunner()) {
     installer = require('./windows')
+    installOptions['ridk'] = inputs['ridk']
   } else {
     installer = require('./ruby-builder')
   }
@@ -70,7 +72,7 @@ export async function setupRuby(options = {}) {
     await require('./windows').installJRubyTools()
   }
 
-  const rubyPrefix = await installer.install(platform, engine, version)
+  const rubyPrefix = await installer.install(platform, engine, version, installOptions)
 
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -17,7 +17,7 @@ export function getAvailableVersions(platform, engine) {
   return rubyBuilderVersions[engine]
 }
 
-export async function install(platform, engine, version) {
+export async function install(platform, engine, version, installOptions) {
   let rubyPrefix, inToolCache
   if (common.shouldUseToolCache(engine, version)) {
     inToolCache = common.toolCacheFind(engine, version)

--- a/windows.js
+++ b/windows.js
@@ -41,7 +41,7 @@ export function getAvailableVersions(platform, engine) {
   }
 }
 
-export async function install(platform, engine, version) {
+export async function install(platform, engine, version, installOptions) {
   const url = rubyInstallerVersions[version]
 
   // The windows-2016 and windows-2019 images have MSYS2 build tools (C:/msys64/usr)
@@ -90,7 +90,7 @@ export async function install(platform, engine, version) {
   }
 
   const ridk = `${rubyPrefix}\\bin\\ridk.cmd`
-  if (fs.existsSync(ridk)) {
+  if (fs.existsSync(ridk) && installOptions['ridk'] !== 'none') {
     await common.measure('Adding ridk env variables', async () => addRidkEnv(ridk))
   }
 


### PR DESCRIPTION
I tried to use `ruby/setup-ruby` to set up `PATH` in mswin build on `ruby/ruby` https://github.com/ruby/ruby/pull/9566, but ridk environment variables added by it seem to break the build:

```
Run ../src/win32/configure.bat --disable-install-doc --with-opt-dir=C:/vcpkg/installed/x64-windows
../src/win32/setup.mak:3: *** missing separator.  Stop.
NMAKE : fatal error U1077: 'C:\msys64\usr\bin\make.exe' : return code '0x2'
Stop.
```

Since only `PATH` is needed for the mswin build and adding ridk environment variables only breaks it, I'd like to add an option to disable those environment variables. This PR proposes to add it as `ridk: none`.