### PR TITLE
Add windows-toolchain input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,6 +335,19 @@ jobs:
           bundler-cache: true
       - run: bundle list | grep nokogiri
 
+  testWindowsToolchain:
+    name: "Test windows-toolchain: none"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          ruby-version: '2.7'
+          windows-toolchain: none
+          bundler: none
+      - name: C:/msys64/mingw64/bin/gcc.exe not installed
+        run: ruby -e "abort if File.exist?('C:/msys64/mingw64/bin/gcc.exe')"
+
   lint:
     runs-on: ubuntu-20.04
     steps:

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,16 @@ inputs:
       Consider the runner as a self-hosted runner, which means not using prebuilt Ruby binaries which only work
       on GitHub-hosted runners or self-hosted runners with a very similar image to the ones used by GitHub runners.
       The default is to detect this automatically based on the OS, OS version and architecture.
+  windows-toolchain:
+    description: |
+      This input allows to override the default toolchain setup on Windows.
+      The default setting ('default') installs a toolchain based on the selected Ruby.
+      Specifically, it installs MSYS2 if not already there and installs mingw/ucrt/mswin build tools and packages.
+      It also sets environment variables using 'ridk' or 'vcvars64.bat' based on the selected Ruby.
+      At present, the only other setting than 'default' is 'none', which only adds Ruby to PATH.
+      No build tools or packages are installed, nor are any ENV setting changed to activate them.
+    default: 'default'
+
 outputs:
   ruby-prefix:
     description: 'The prefix of the installed ruby'

--- a/common.js
+++ b/common.js
@@ -341,7 +341,8 @@ export function setupPath(newPathEntries) {
 
   // Then add new path entries using core.addPath()
   let newPath
-  if (windows) {
+  const windowsToolchain = core.getInput('windows-toolchain')
+  if (windows && windowsToolchain !== 'none') {
     // main Ruby dll determines whether mingw or ucrt build
     msys2Type = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -701,7 +701,8 @@ function setupPath(newPathEntries) {
 
   // Then add new path entries using core.addPath()
   let newPath
-  if (windows) {
+  const windowsToolchain = core.getInput('windows-toolchain')
+  if (windows && windowsToolchain !== 'none') {
     // main Ruby dll determines whether mingw or ucrt build
     msys2Type = rubyIsUCRT(newPathEntries[0]) ? 'ucrt64' : 'mingw64'
 
@@ -65232,12 +65233,17 @@ async function install(platform, engine, version) {
     rubyPrefix = `${drive}:\\${base}`
   }
 
-  let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
 
+  const windowsToolchain = core.getInput('windows-toolchain')
+  if (windowsToolchain === 'none') {
+    common.setupPath([`${rubyPrefix}\\bin`])
+    return rubyPrefix
+  }
+
+  let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
   const msys2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   // install msys2 tools for all Ruby versions, only install mingw or ucrt for Rubies >= 2.4
@@ -65748,6 +65754,7 @@ const inputDefaults = {
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
   'self-hosted': 'false',
+  'windows-toolchain': 'default',
 }
 
 // entry point when this action is run on its own

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const inputDefaults = {
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
   'self-hosted': 'false',
+  'windows-toolchain': 'default',
 }
 
 // entry point when this action is run on its own

--- a/windows.js
+++ b/windows.js
@@ -65,12 +65,17 @@ export async function install(platform, engine, version) {
     rubyPrefix = `${drive}:\\${base}`
   }
 
-  let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
-
   if (!inToolCache) {
     await downloadAndExtract(engine, version, url, base, rubyPrefix);
   }
 
+  const windowsToolchain = core.getInput('windows-toolchain')
+  if (windowsToolchain === 'none') {
+    common.setupPath([`${rubyPrefix}\\bin`])
+    return rubyPrefix
+  }
+
+  let toolchainPaths = (version === 'mswin') ? await setupMSWin() : await setupMingw(version)
   const msys2Type = common.setupPath([`${rubyPrefix}\\bin`, ...toolchainPaths])
 
   // install msys2 tools for all Ruby versions, only install mingw or ucrt for Rubies >= 2.4


### PR DESCRIPTION
Adds a `windows-toolchain` input.

1. Only affects Windows Rubies.
2. Current PR allows only one optional setting, which is `none`.  It installs the selected Ruby and adds it to `PATH`.  No build tools are installed/activated.  Hence, no extension gems can be compiled/installed via bundler.

Closes #562