### PR TITLE
Remove extra space in "Extracting Ruby" build step

### DIFF
--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -91,7 +91,7 @@ async function downloadAndExtract(platform, engine, version, rubyPrefix) {
     return await tc.downloadTool(url)
   })
 
-  await common.measure('Extracting  Ruby', async () => {
+  await common.measure('Extracting Ruby', async () => {
     if (windows) {
       // Windows 2016 doesn't have system tar, use MSYS2's, it needs unix style paths
       await exec.exec('tar', ['-xz', '-C', common.win2nix(parentDir), '-f', common.win2nix(downloadPath)])


### PR DESCRIPTION
I noticed an extra space in "Extracting &nbsp;Ruby":

<img width="289" alt="image" src="https://github.com/ruby/setup-ruby/assets/923242/6bd04bb0-2c31-473e-8291-b5f0d452222b">

This fixes that by removing the extra space.