### PR TITLE
Removed macos-arm-oss from GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14, macos-arm-oss, windows-2019, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14, windows-2019, windows-2022 ]
         ruby: [
           '1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', ruby-head,
           jruby, jruby-head,
@@ -35,7 +35,7 @@ jobs:
         - { os: ubuntu-22.04, ruby: '2.2' }
         - { os: ubuntu-24.04, ruby: '1.9' }
         - { os: ubuntu-24.04, ruby: '2.2' }
-        # These old Rubies fail to compile on macos-arm-oss (macOS 13, arm64), which is used for ruby/ruby-builder
+        # These old Rubies fail to compile on macos-14 (macOS 14, arm64), which is used for ruby/ruby-builder
         - { os: macos-14, ruby: '1.9' }
         - { os: macos-14, ruby: '2.0' }
         - { os: macos-14, ruby: '2.1' }
@@ -43,13 +43,6 @@ jobs:
         - { os: macos-14, ruby: '2.3' }
         - { os: macos-14, ruby: '2.4' }
         - { os: macos-14, ruby: '2.5' }
-        - { os: macos-arm-oss, ruby: '1.9' }
-        - { os: macos-arm-oss, ruby: '2.0' }
-        - { os: macos-arm-oss, ruby: '2.1' }
-        - { os: macos-arm-oss, ruby: '2.2' }
-        - { os: macos-arm-oss, ruby: '2.3' }
-        - { os: macos-arm-oss, ruby: '2.4' }
-        - { os: macos-arm-oss, ruby: '2.5' }
         # Windows
         - { os: windows-2019, ruby: '1.9' }
         - { os: windows-2019, ruby: debug }


### PR DESCRIPTION
Unfortunately, we lost `macos-arm-oss` runner from ruby org.