### PR TITLE
README.md - Windows - clarify installed packages, 2022 vs 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ It is recommended to first get your build working on Ubuntu and macOS before try
 * For Ruby < 2.4, the DevKit MSYS tools are installed and prepended to the `Path`.
 * Use JRuby 9.2.20+ on Windows (older versions have [bugs](https://github.com/ruby/setup-ruby/issues/18#issuecomment-889072695)).
 * JRuby on Windows has multiple issues ([jruby/jruby#7106](https://github.com/jruby/jruby/issues/7106), [jruby/jruby#7182](https://github.com/jruby/jruby/issues/7182)).
+* When compiling extension code, note that the packages required to build Ruby are included when using Windows 2022, but that Windows 2019 does not include all of them, and may require installing package(s).  This can be done with [setup-ruby-pkgs](https://github.com/ruby/setup-ruby-pkgs) or via MSYS2's pacman.  These packages may be required when installing or updating Ruby std-lib extension gems.
 
 ## Versioning
 


### PR DESCRIPTION
Clarify that the pre-installed Windows MSYS2 packages vary by Actions image (Windows 2019 vs Windows 2022)

Closes #641