### PR TITLE
Use case-insensitive key comparison for cache keys

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -209,7 +209,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   await exec.exec('bundle', ['install', '--jobs', '4'])
 
   // @actions/cache only allows to save for non-existing keys
-  if (cachedKey !== key) {
+  if (!common.isExactKeyMatch(key, cachedKey)) {
     if (cachedKey) { // existing cache but Gemfile.lock differs, clean old gems
       await exec.exec('bundle', ['clean'])
     }

--- a/common.js
+++ b/common.js
@@ -393,3 +393,15 @@ export function setupPath(newPathEntries) {
   core.addPath(newPath.join(path.delimiter))
   return msys2Type
 }
+
+// Determines if two keys are an exact match for the purposes of cache matching
+// Specifically, this is a case-insensitive match that ignores accents
+// From actions/cache@v3 src/utils/actionUtils.ts (MIT)
+export function isExactKeyMatch(key, cacheKey) {
+  return !!(
+      cacheKey &&
+      cacheKey.localeCompare(key, undefined, {
+          sensitivity: 'accent'
+      }) === 0
+  );
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -223,7 +223,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
   await exec.exec('bundle', ['install', '--jobs', '4'])
 
   // @actions/cache only allows to save for non-existing keys
-  if (cachedKey !== key) {
+  if (!common.isExactKeyMatch(key, cachedKey)) {
     if (cachedKey) { // existing cache but Gemfile.lock differs, clean old gems
       await exec.exec('bundle', ['clean'])
     }
@@ -315,7 +315,8 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "toolCacheCompleteFile": () => (/* binding */ toolCacheCompleteFile),
 /* harmony export */   "createToolCacheCompleteFile": () => (/* binding */ createToolCacheCompleteFile),
 /* harmony export */   "win2nix": () => (/* binding */ win2nix),
-/* harmony export */   "setupPath": () => (/* binding */ setupPath)
+/* harmony export */   "setupPath": () => (/* binding */ setupPath),
+/* harmony export */   "isExactKeyMatch": () => (/* binding */ isExactKeyMatch)
 /* harmony export */ });
 const os = __nccwpck_require__(2037)
 const path = __nccwpck_require__(1017)
@@ -711,6 +712,18 @@ function setupPath(newPathEntries) {
 
   core.addPath(newPath.join(path.delimiter))
   return msys2Type
+}
+
+// Determines if two keys are an exact match for the purposes of cache matching
+// Specifically, this is a case-insensitive match that ignores accents
+// From actions/cache@v3 src/utils/actionUtils.ts (MIT)
+function isExactKeyMatch(key, cacheKey) {
+  return !!(
+      cacheKey &&
+      cacheKey.localeCompare(key, undefined, {
+          sensitivity: 'accent'
+      }) === 0
+  );
 }
 
 


### PR DESCRIPTION
Following the discussion in #659, this PR introduces a case-insensitive cache key comparison function to compare the cache key returned from `@actions/cache` versus the calculated cache key for the purposes of partial-hits.

This implementation follows that which is used in [`actions/cache`](https://github.com/actions/cache/blob/8469c94c6a180dfb41a1bd7e1b46ac557ea124f1/src/utils/actionUtils.ts#L13-L20). Unfortunately, that implementation isn't in the accompanying Node package, so I've copied it here.