### PR TITLE
Fixes the latest rubygems installation error with Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,8 +190,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { ruby: '3.2', expected_rubygems_version: '3.5.3'  }
-        - { ruby: '3.0', expected_rubygems_version: '3.5.3'  }
+        - { ruby: '3.2', expected_rubygems_version: '3.6.1'  }
+        - { ruby: '3.0', expected_rubygems_version: '3.5.23' }
         - { ruby: '2.7', expected_rubygems_version: '3.4.22' }
         - { ruby: '2.6', expected_rubygems_version: '3.4.22' }
         - { ruby: '2.5', expected_rubygems_version: '3.3.27' }

--- a/dist/index.js
+++ b/dist/index.js
@@ -65114,8 +65114,10 @@ async function rubygemsLatest(gem, platform, engine, rubyVersion) {
     const floatVersion = common.floatVersion(rubyVersion)
     if (common.isHeadVersion(rubyVersion)) {
       console.log('Ruby master builds use included RubyGems')
-    } else if (floatVersion >= 3.0) {
+    } else if (floatVersion >= 3.1) {
       await exec.exec(gem, ['update', '--system'])
+    } else if (floatVersion >= 3.0) {
+      await exec.exec(gem, ['update', '--system', '3.5.23'])
     } else if (floatVersion >= 2.6) {
       await exec.exec(gem, ['update', '--system', '3.4.22'])
     } else if (floatVersion >= 2.3) {

--- a/rubygems.js
+++ b/rubygems.js
@@ -39,8 +39,10 @@ async function rubygemsLatest(gem, platform, engine, rubyVersion) {
     const floatVersion = common.floatVersion(rubyVersion)
     if (common.isHeadVersion(rubyVersion)) {
       console.log('Ruby master builds use included RubyGems')
-    } else if (floatVersion >= 3.0) {
+    } else if (floatVersion >= 3.1) {
       await exec.exec(gem, ['update', '--system'])
+    } else if (floatVersion >= 3.0) {
+      await exec.exec(gem, ['update', '--system', '3.5.23'])
     } else if (floatVersion >= 2.6) {
       await exec.exec(gem, ['update', '--system', '3.4.22'])
     } else if (floatVersion >= 2.3) {


### PR DESCRIPTION
If set up `rubygems: latest` in workflow,
it will cause the error with Ruby 3.0 because the latest rubygems does not support Ruby 3.0.

Ref. https://rubygems.org/gems/rubygems-update

### Error message
```
Updating RubyGems
  /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/gem --version
  3.2.33
  Default RubyGems version is 3.2.33
  Updating RubyGems to latest version
  /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/gem update --system
  ERROR:  Error installing rubygems-update:
  	rubygems-update-3.6.1 requires Ruby version >= 3.1.0. The current ruby version is 3.0.7.220.
  ERROR:  While executing gem ... (NoMethodError)
      undefined method `version' for nil:NilClass
  Updating rubygems-update
  Took   2.86 seconds
Error: The process '/opt/hostedtoolcache/Ruby/3.0.7/x64/bin/gem' failed with exit code 1
```

### How to reproduce
```
        uses: ruby/setup-ruby@v1
        with:
          ruby-version: "3.0"
          rubygems: latest
```