### PR TITLE
Call "add-platform" before "bundle install" when using cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   bundler-cache:
     description: 'Run "bundle install", and cache the result automatically. Either true or false.'
     default: 'false'
+  add-platform:
+    description: 'Run "bundle lock --add-platform" before "bundle install" when using "bundler-cache"'
+    default: 'false'
   working-directory:
     description: 'The working directory to use for resolving paths for .ruby-version, .tool-versions, mise.toml and Gemfile.lock.'
   cache-version:

--- a/bundler.js
+++ b/bundler.js
@@ -232,6 +232,14 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   return true
 }
 
+export async function addPlatform(lockFile) {
+  if (fs.existsSync(lockFile)) {
+    const output = (await exec.getExecOutput('ruby', ['-e', 'p Gem::Platform.local.to_s'])).stdout
+    const platform = output.slice(1, output.length - 2)
+    await exec.getExecOutput('bundle', ['lock', '--add-platform', platform, `--lockfile=${lockFile}`])
+  }
+}
+
 async function computeBaseKey(platform, engine, version, lockFile, cacheVersion) {
   const cwd = process.cwd()
   const bundleWith = process.env['BUNDLE_WITH'] || ''

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const inputDefaults = {
   'rubygems': 'default',
   'bundler': 'Gemfile.lock',
   'bundler-cache': 'false',
+  'add-platform': 'false',
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
   'self-hosted': 'false',
@@ -104,6 +105,10 @@ export async function setupRuby(options = {}) {
   }
 
   if (inputs['bundler-cache'] === 'true') {
+    if (inputs['add-platform'] === 'true') {
+      await bundler.addPlatform(lockFile)
+    }
+    
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
   }


### PR DESCRIPTION
I've ran into an annoying issue using macos runner on Github Action and using lockfile where the platform id could change at a moment notice meaning that I would be greeted with this error:

```console
Your bundle only supports platforms ["x64-mingw-ucrt", "x86_64-linux", "x86_64-darwin-21"] but your
local platform is x86_64-darwin-22. Add the current platform to the lockfile
with
`bundle lock --add-platform x86_64-darwin-22` and try again.
```

Obviously, running `bundle lock --add-platform x86_64-darwin-22` fixes the issue, but that action used to run without any issues and now despite using `macos-13` (not `macos-latest`), I get this error. Very annoying and not "future-proof".

So I propose the addition of the `add-platform` input which call this command before `bundle install` ensuring that the platform is present in the lockfile. 