### PR TITLE
[Fixes #716] deal with multiple versions in .tool-versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74933,7 +74933,7 @@ function parseRubyEngineAndVersion(rubyVersion) {
   } else if (rubyVersion === '.tool-versions') { // Read from .tool-versions
     const toolVersions = fs.readFileSync('.tool-versions', 'utf8').trim()
     const rubyLine = toolVersions.split(/\r?\n/).filter(e => /^ruby\s/.test(e))[0]
-    rubyVersion = rubyLine.match(/^ruby\s+(.+)$/)[1]
+    rubyVersion = rubyLine.split(/\s/)[1]
     console.log(`Using ${rubyVersion} as input from file .tool-versions`)
   } else if (rubyVersion === 'mise.toml') { // Read from mise.toml
     const toolVersions = fs.readFileSync('mise.toml', 'utf8').trim()

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function parseRubyEngineAndVersion(rubyVersion) {
   } else if (rubyVersion === '.tool-versions') { // Read from .tool-versions
     const toolVersions = fs.readFileSync('.tool-versions', 'utf8').trim()
     const rubyLine = toolVersions.split(/\r?\n/).filter(e => /^ruby\s/.test(e))[0]
-    rubyVersion = rubyLine.match(/^ruby\s+(.+)$/)[1]
+    rubyVersion = rubyLine.split(/\s/)[1]
     console.log(`Using ${rubyVersion} as input from file .tool-versions`)
   } else if (rubyVersion === 'mise.toml') { // Read from mise.toml
     const toolVersions = fs.readFileSync('mise.toml', 'utf8').trim()


### PR DESCRIPTION
See #716  for explanation

Tested on one of my projects: https://github.com/jtannas/katachi/actions/runs/13660430691/job/38190080032?pr=19

While it might be cool for it to attempt each ruby version in order (aka. mimic ASDF parsing) or to treat multiple `.tool-versions` entries as a matrix, that's way beyond what I need and am comfortable tackling as a first PR.