### PR TITLE
bugfix: Fix bug that version cannot be parsed in .tool-versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74933,7 +74933,7 @@ function parseRubyEngineAndVersion(rubyVersion) {
   } else if (rubyVersion === '.tool-versions') { // Read from .tool-versions
     const toolVersions = fs.readFileSync('.tool-versions', 'utf8').trim()
     const rubyLine = toolVersions.split(/\r?\n/).filter(e => /^ruby\s/.test(e))[0]
-    rubyVersion = rubyLine.split(/\s/)[1]
+    rubyVersion = rubyLine.split(/\s+/)[1]
     console.log(`Using ${rubyVersion} as input from file .tool-versions`)
   } else if (rubyVersion === 'mise.toml') { // Read from mise.toml
     const toolVersions = fs.readFileSync('mise.toml', 'utf8').trim()

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function parseRubyEngineAndVersion(rubyVersion) {
   } else if (rubyVersion === '.tool-versions') { // Read from .tool-versions
     const toolVersions = fs.readFileSync('.tool-versions', 'utf8').trim()
     const rubyLine = toolVersions.split(/\r?\n/).filter(e => /^ruby\s/.test(e))[0]
-    rubyVersion = rubyLine.split(/\s/)[1]
+    rubyVersion = rubyLine.split(/\s+/)[1]
     console.log(`Using ${rubyVersion} as input from file .tool-versions`)
   } else if (rubyVersion === 'mise.toml') { // Read from mise.toml
     const toolVersions = fs.readFileSync('mise.toml', 'utf8').trim()


### PR DESCRIPTION
close: #719

This PR fixes a regression introduced in PR #717, where the tool fails to correctly parse the Ruby version from .tool-versions when multiple spaces exist between the tool name and version.