### PR TITLE
Switch JAVA_HOME to 21 for JRuby

### DIFF
--- a/common.js
+++ b/common.js
@@ -406,7 +406,11 @@ export function setupPath(newPathEntries) {
 
 export function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
-  let newHomeVar = `JAVA_HOME_21_${os.arch().toUpperCase()}`;
+  let arch = os.arch();
+  if (arch == "x64") {
+    arch = "X64"
+  }
+  let newHomeVar = `JAVA_HOME_21_${arch}`;
   let newHome = process.env[newHomeVar];
   console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
   core.exportVariable("JAVA_HOME", newHome);

--- a/common.js
+++ b/common.js
@@ -1,5 +1,3 @@
-import exec from "@actions/exec";
-
 const os = require('os')
 const path = require('path')
 const fs = require('fs')
@@ -8,6 +6,7 @@ const stream = require('stream')
 const crypto = require('crypto')
 const core = require('@actions/core')
 const tc = require('@actions/tool-cache')
+const exec = require('@actions/exec')
 const { performance } = require('perf_hooks')
 const linuxOSInfo = require('linux-os-info')
 

--- a/common.js
+++ b/common.js
@@ -407,7 +407,7 @@ export function setupPath(newPathEntries) {
 export function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
   let arch = os.arch();
-  if (arch == "x64") {
+  if (arch == "x64" || os.platform() != "darwin") {
     arch = "X64"
   }
   let newHomeVar = `JAVA_HOME_21_${arch}`;

--- a/common.js
+++ b/common.js
@@ -410,23 +410,28 @@ export async function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
 
   console.log("attempting to run with existing JAVA_HOME")
-  let ret = await exec.exec('ruby', ['--version']);
+
+  let ret = await exec.exec('ruby', ['--version'])
 
   if (ret === 0) {
     console.log("JRuby successfully starts, using existing JAVA_HOME")
   } else {
     console.log("JRuby failed to start, try Java 21 envs")
+
     let arch = os.arch();
-    if (arch == "x64" || os.platform() != "darwin") {
+    if (arch === "x64" || os.platform() !== "darwin") {
       arch = "X64"
     }
-    let newHomeVar = `JAVA_HOME_21_${arch}`;
-    let newHome = process.env[newHomeVar];
+
+    let newHomeVar = `JAVA_HOME_21_${arch}`
+    let newHome = process.env[newHomeVar]
 
     if (newHome === "undefined") {
       throw new Error(`JAVA_HOME is not Java 21+ needed for JRuby and \$${newHomeVar} is not defined`)
     }
+
     console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
+
     core.exportVariable("JAVA_HOME", newHome)
   }
 

--- a/common.js
+++ b/common.js
@@ -417,7 +417,7 @@ export async function setupJavaHome() {
   } else {
     console.log("JRuby failed to start, try Java 21 envs")
 
-    let arch = os.arch();
+    let arch = os.arch()
     if (arch === "x64" || os.platform() !== "darwin") {
       arch = "X64"
     }

--- a/common.js
+++ b/common.js
@@ -7,7 +7,6 @@ const crypto = require('crypto')
 const core = require('@actions/core')
 const tc = require('@actions/tool-cache')
 const exec = require('@actions/exec')
-const common = require('./common')
 const { performance } = require('perf_hooks')
 const linuxOSInfo = require('linux-os-info')
 
@@ -407,7 +406,7 @@ export function setupPath(newPathEntries) {
 }
 
 export async function setupJavaHome() {
-  common.measure("Modifying JAVA_HOME for JRuby", async () => {
+  await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
     let ret = await exec.exec('ruby', ['--version'])

--- a/common.js
+++ b/common.js
@@ -403,3 +403,7 @@ export function setupPath(newPathEntries) {
   core.addPath(newPath.join(path.delimiter))
   return msys2Type
 }
+
+export function setupJavaHome() {
+  core.exportVariable("JAVA_HOME", process.env[`JAVA_HOME_21_${os.arch().toUpperCase()}`]);
+}

--- a/common.js
+++ b/common.js
@@ -405,5 +405,10 @@ export function setupPath(newPathEntries) {
 }
 
 export function setupJavaHome() {
-  core.exportVariable("JAVA_HOME", process.env[`JAVA_HOME_21_${os.arch().toUpperCase()}`]);
+  core.startGroup(`Modifying JAVA_HOME for JRuby`)
+  let newHomeVar = `JAVA_HOME_21_${os.arch().toUpperCase()}`;
+  let newHome = process.env[newHomeVar];
+  console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
+  core.exportVariable("JAVA_HOME", newHome);
+  core.endGroup()
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -726,7 +726,11 @@ function setupPath(newPathEntries) {
 
 function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
-  let newHomeVar = `JAVA_HOME_21_${os.arch().toUpperCase()}`;
+  let arch = os.arch();
+  if (arch == "x64") {
+    arch = "X64"
+  }
+  let newHomeVar = `JAVA_HOME_21_${arch}`;
   let newHome = process.env[newHomeVar];
   console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
   core.exportVariable("JAVA_HOME", newHome);

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,7 +327,6 @@ const crypto = __nccwpck_require__(6113)
 const core = __nccwpck_require__(2186)
 const tc = __nccwpck_require__(7784)
 const exec = __nccwpck_require__(1514)
-const common = __nccwpck_require__(4717)
 const { performance } = __nccwpck_require__(4074)
 const linuxOSInfo = __nccwpck_require__(8487)
 
@@ -727,7 +726,7 @@ function setupPath(newPathEntries) {
 }
 
 async function setupJavaHome() {
-  common.measure("Modifying JAVA_HOME for JRuby", async () => {
+  await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
     let ret = await exec.exec('ruby', ['--version'])

--- a/dist/index.js
+++ b/dist/index.js
@@ -315,7 +315,8 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "toolCacheCompleteFile": () => (/* binding */ toolCacheCompleteFile),
 /* harmony export */   "createToolCacheCompleteFile": () => (/* binding */ createToolCacheCompleteFile),
 /* harmony export */   "win2nix": () => (/* binding */ win2nix),
-/* harmony export */   "setupPath": () => (/* binding */ setupPath)
+/* harmony export */   "setupPath": () => (/* binding */ setupPath),
+/* harmony export */   "setupJavaHome": () => (/* binding */ setupJavaHome)
 /* harmony export */ });
 const os = __nccwpck_require__(2037)
 const path = __nccwpck_require__(1017)
@@ -721,6 +722,15 @@ function setupPath(newPathEntries) {
 
   core.addPath(newPath.join(path.delimiter))
   return msys2Type
+}
+
+function setupJavaHome() {
+  core.startGroup(`Modifying JAVA_HOME for JRuby`)
+  let newHomeVar = `JAVA_HOME_21_${os.arch().toUpperCase()}`;
+  let newHome = process.env[newHomeVar];
+  console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
+  core.exportVariable("JAVA_HOME", newHome);
+  core.endGroup()
 }
 
 
@@ -74051,6 +74061,10 @@ async function install(platform, engine, version) {
 
   // Set the PATH now, so the MSYS2 'tar' is in Path on Windows
   common.setupPath([path.join(rubyPrefix, 'bin')])
+
+  if (engine == "jruby") {
+    common.setupJavaHome();
+  }
 
   if (!inToolCache) {
     await io.mkdirP(rubyPrefix)

--- a/dist/index.js
+++ b/dist/index.js
@@ -318,10 +318,6 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony export */   "setupPath": () => (/* binding */ setupPath),
 /* harmony export */   "setupJavaHome": () => (/* binding */ setupJavaHome)
 /* harmony export */ });
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(1514);
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
-
-
 const os = __nccwpck_require__(2037)
 const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7147)
@@ -330,6 +326,7 @@ const stream = __nccwpck_require__(2781)
 const crypto = __nccwpck_require__(6113)
 const core = __nccwpck_require__(2186)
 const tc = __nccwpck_require__(7784)
+const exec = __nccwpck_require__(1514)
 const { performance } = __nccwpck_require__(4074)
 const linuxOSInfo = __nccwpck_require__(8487)
 
@@ -733,7 +730,7 @@ async function setupJavaHome() {
 
   console.log("attempting to run with existing JAVA_HOME")
 
-  let ret = await _actions_exec__WEBPACK_IMPORTED_MODULE_0___default().exec('ruby', ['--version'])
+  let ret = await exec.exec('ruby', ['--version'])
 
   if (ret === 0) {
     console.log("JRuby successfully starts, using existing JAVA_HOME")
@@ -74796,18 +74793,6 @@ module.exports = JSON.parse('{"2.0.0":"https://github.com/oneclick/rubyinstaller
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat get default export */
-/******/ 	(() => {
-/******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__nccwpck_require__.n = (module) => {
-/******/ 			var getter = module && module.__esModule ?
-/******/ 				() => (module['default']) :
-/******/ 				() => (module);
-/******/ 			__nccwpck_require__.d(getter, { a: getter });
-/******/ 			return getter;
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports

--- a/dist/index.js
+++ b/dist/index.js
@@ -737,7 +737,7 @@ async function setupJavaHome() {
   } else {
     console.log("JRuby failed to start, try Java 21 envs")
 
-    let arch = os.arch();
+    let arch = os.arch()
     if (arch === "x64" || os.platform() !== "darwin") {
       arch = "X64"
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,6 +327,7 @@ const crypto = __nccwpck_require__(6113)
 const core = __nccwpck_require__(2186)
 const tc = __nccwpck_require__(7784)
 const exec = __nccwpck_require__(1514)
+const common = __nccwpck_require__(4717)
 const { performance } = __nccwpck_require__(4074)
 const linuxOSInfo = __nccwpck_require__(8487)
 
@@ -726,35 +727,33 @@ function setupPath(newPathEntries) {
 }
 
 async function setupJavaHome() {
-  core.startGroup(`Modifying JAVA_HOME for JRuby`)
+  common.measure("Modifying JAVA_HOME for JRuby", async () => {
+    console.log("attempting to run with existing JAVA_HOME")
 
-  console.log("attempting to run with existing JAVA_HOME")
+    let ret = await exec.exec('ruby', ['--version'])
 
-  let ret = await exec.exec('ruby', ['--version'])
+    if (ret === 0) {
+      console.log("JRuby successfully starts, using existing JAVA_HOME")
+    } else {
+      console.log("JRuby failed to start, try Java 21 envs")
 
-  if (ret === 0) {
-    console.log("JRuby successfully starts, using existing JAVA_HOME")
-  } else {
-    console.log("JRuby failed to start, try Java 21 envs")
+      let arch = os.arch()
+      if (arch === "x64" || os.platform() !== "darwin") {
+        arch = "X64"
+      }
 
-    let arch = os.arch()
-    if (arch === "x64" || os.platform() !== "darwin") {
-      arch = "X64"
+      let newHomeVar = `JAVA_HOME_21_${arch}`
+      let newHome = process.env[newHomeVar]
+
+      if (newHome === "undefined") {
+        throw new Error(`JAVA_HOME is not Java 21+ needed for JRuby and \$${newHomeVar} is not defined`)
+      }
+
+      console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
+
+      core.exportVariable("JAVA_HOME", newHome)
     }
-
-    let newHomeVar = `JAVA_HOME_21_${arch}`
-    let newHome = process.env[newHomeVar]
-
-    if (newHome === "undefined") {
-      throw new Error(`JAVA_HOME is not Java 21+ needed for JRuby and \$${newHomeVar} is not defined`)
-    }
-
-    console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
-
-    core.exportVariable("JAVA_HOME", newHome)
-  }
-
-  core.endGroup()
+  })
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -727,7 +727,7 @@ function setupPath(newPathEntries) {
 function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
   let arch = os.arch();
-  if (arch == "x64") {
+  if (arch == "x64" || os.platform() != "darwin") {
     arch = "X64"
   }
   let newHomeVar = `JAVA_HOME_21_${arch}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -732,23 +732,28 @@ async function setupJavaHome() {
   core.startGroup(`Modifying JAVA_HOME for JRuby`)
 
   console.log("attempting to run with existing JAVA_HOME")
-  let ret = await _actions_exec__WEBPACK_IMPORTED_MODULE_0___default().exec('ruby', ['--version']);
+
+  let ret = await _actions_exec__WEBPACK_IMPORTED_MODULE_0___default().exec('ruby', ['--version'])
 
   if (ret === 0) {
     console.log("JRuby successfully starts, using existing JAVA_HOME")
   } else {
     console.log("JRuby failed to start, try Java 21 envs")
+
     let arch = os.arch();
-    if (arch == "x64" || os.platform() != "darwin") {
+    if (arch === "x64" || os.platform() !== "darwin") {
       arch = "X64"
     }
-    let newHomeVar = `JAVA_HOME_21_${arch}`;
-    let newHome = process.env[newHomeVar];
+
+    let newHomeVar = `JAVA_HOME_21_${arch}`
+    let newHome = process.env[newHomeVar]
 
     if (newHome === "undefined") {
       throw new Error(`JAVA_HOME is not Java 21+ needed for JRuby and \$${newHomeVar} is not defined`)
     }
+
     console.log(`Setting JAVA_HOME to ${newHomeVar} path ${newHome}`)
+
     core.exportVariable("JAVA_HOME", newHome)
   }
 
@@ -74926,8 +74931,8 @@ async function setupRuby(options = {}) {
 
   const rubyPrefix = await installer.install(platform, engine, version)
 
-  if (engine == "jruby") {
-    await common.setupJavaHome();
+  if (engine === "jruby") {
+    await common.setupJavaHome()
   }
 
   await common.measure('Print Ruby version', async () =>

--- a/dist/index.js
+++ b/dist/index.js
@@ -74091,6 +74091,11 @@ async function install(platform, engine, version) {
     await downloadAndExtract(platform, engine, version, rubyPrefix)
   }
 
+  // Ensure JRuby has minimum Java version to run
+  if (engine === "jruby") {
+    await common.setupJavaHome()
+  }
+
   return rubyPrefix
 }
 
@@ -74915,10 +74920,6 @@ async function setupRuby(options = {}) {
   }
 
   const rubyPrefix = await installer.install(platform, engine, version)
-
-  if (engine === "jruby") {
-    await common.setupJavaHome()
-  }
 
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))

--- a/index.js
+++ b/index.js
@@ -79,6 +79,10 @@ export async function setupRuby(options = {}) {
 
   const rubyPrefix = await installer.install(platform, engine, version)
 
+  if (engine == "jruby") {
+    await common.setupJavaHome();
+  }
+
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))
 

--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ export async function setupRuby(options = {}) {
 
   const rubyPrefix = await installer.install(platform, engine, version)
 
-  if (engine == "jruby") {
-    await common.setupJavaHome();
+  if (engine === "jruby") {
+    await common.setupJavaHome()
   }
 
   await common.measure('Print Ruby version', async () =>

--- a/index.js
+++ b/index.js
@@ -79,10 +79,6 @@ export async function setupRuby(options = {}) {
 
   const rubyPrefix = await installer.install(platform, engine, version)
 
-  if (engine === "jruby") {
-    await common.setupJavaHome()
-  }
-
   await common.measure('Print Ruby version', async () =>
     await exec.exec('ruby', ['--version']))
 

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -49,10 +49,6 @@ export async function install(platform, engine, version) {
   // Set the PATH now, so the MSYS2 'tar' is in Path on Windows
   common.setupPath([path.join(rubyPrefix, 'bin')])
 
-  if (engine == "jruby") {
-    common.setupJavaHome();
-  }
-
   if (!inToolCache) {
     await io.mkdirP(rubyPrefix)
     await downloadAndExtract(platform, engine, version, rubyPrefix)

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -49,6 +49,10 @@ export async function install(platform, engine, version) {
   // Set the PATH now, so the MSYS2 'tar' is in Path on Windows
   common.setupPath([path.join(rubyPrefix, 'bin')])
 
+  if (engine == "jruby") {
+    common.setupJavaHome();
+  }
+
   if (!inToolCache) {
     await io.mkdirP(rubyPrefix)
     await downloadAndExtract(platform, engine, version, rubyPrefix)

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -54,6 +54,11 @@ export async function install(platform, engine, version) {
     await downloadAndExtract(platform, engine, version, rubyPrefix)
   }
 
+  // Ensure JRuby has minimum Java version to run
+  if (engine === "jruby") {
+    await common.setupJavaHome()
+  }
+
   return rubyPrefix
 }
 


### PR DESCRIPTION
JRuby 10 requires Java 21. Since the previous default was 17 and all JRuby releases should work fine on 21, we do this for all JRuby installs.

Implements #718