### PR TITLE
Handle exec error

### DIFF
--- a/common.js
+++ b/common.js
@@ -409,7 +409,7 @@ export async function setupJavaHome() {
   await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
-    let ret = await exec.exec('ruby', ['--version'])
+    let ret = await exec.exec('ruby', ['--version'], {ignoreReturnCode: true})
 
     if (ret === 0) {
       console.log("JRuby successfully starts, using existing JAVA_HOME")

--- a/common.js
+++ b/common.js
@@ -405,11 +405,11 @@ export function setupPath(newPathEntries) {
   return msys2Type
 }
 
-export async function setupJavaHome() {
+export async function setupJavaHome(rubyPrefix) {
   await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
-    let ret = await exec.exec('ruby', ['--version'], {ignoreReturnCode: true})
+    let ret = await exec.exec('java', ['-jar', path.join(rubyPrefix, 'lib/jruby.jar'), '--version'], {ignoreReturnCode: true})
 
     if (ret === 0) {
       console.log("JRuby successfully starts, using existing JAVA_HOME")

--- a/dist/index.js
+++ b/dist/index.js
@@ -729,7 +729,7 @@ async function setupJavaHome() {
   await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
-    let ret = await exec.exec('ruby', ['--version'])
+    let ret = await exec.exec('ruby', ['--version'], {ignoreReturnCode: true})
 
     if (ret === 0) {
       console.log("JRuby successfully starts, using existing JAVA_HOME")

--- a/dist/index.js
+++ b/dist/index.js
@@ -725,11 +725,11 @@ function setupPath(newPathEntries) {
   return msys2Type
 }
 
-async function setupJavaHome() {
+async function setupJavaHome(rubyPrefix) {
   await measure("Modifying JAVA_HOME for JRuby", async () => {
     console.log("attempting to run with existing JAVA_HOME")
 
-    let ret = await exec.exec('ruby', ['--version'], {ignoreReturnCode: true})
+    let ret = await exec.exec('java', ['-jar', path.join(rubyPrefix, 'lib/jruby.jar'), '--version'], {ignoreReturnCode: true})
 
     if (ret === 0) {
       console.log("JRuby successfully starts, using existing JAVA_HOME")
@@ -74091,7 +74091,7 @@ async function install(platform, engine, version) {
 
   // Ensure JRuby has minimum Java version to run
   if (engine === "jruby") {
-    await common.setupJavaHome()
+    await common.setupJavaHome(rubyPrefix)
   }
 
   return rubyPrefix

--- a/ruby-builder.js
+++ b/ruby-builder.js
@@ -56,7 +56,7 @@ export async function install(platform, engine, version) {
 
   // Ensure JRuby has minimum Java version to run
   if (engine === "jruby") {
-    await common.setupJavaHome()
+    await common.setupJavaHome(rubyPrefix)
   }
 
   return rubyPrefix


### PR DESCRIPTION
Apparently this exec errors when the subprocess fails rather than returning an error code. This causes the whole setup process to terminate. This patch catches the error and uses that to indicate failure to launch.

Hopefully will address the issue in https://github.com/ruby/jruby-dev-builder/pull/10#issuecomment-2722058138