### PR TITLE
Remove unused platform argument from computeBaseKey

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -182,7 +182,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
 
   // cache key
   const paths = [cachePath]
-  const baseKey = await computeBaseKey(platform, engine, rubyVersion, lockFile, cacheVersion)
+  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)
   const key = `${baseKey}-${await common.hashFile(lockFile)}`
   // If only Gemfile.lock changes we can reuse part of the cache, and clean old gem versions below
   const restoreKeys = [`${baseKey}-`]
@@ -232,7 +232,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   return true
 }
 
-async function computeBaseKey(platform, engine, version, lockFile, cacheVersion) {
+async function computeBaseKey(engine, version, lockFile, cacheVersion) {
   const cwd = process.cwd()
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -196,7 +196,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
 
   // cache key
   const paths = [cachePath]
-  const baseKey = await computeBaseKey(platform, engine, rubyVersion, lockFile, cacheVersion)
+  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)
   const key = `${baseKey}-${await common.hashFile(lockFile)}`
   // If only Gemfile.lock changes we can reuse part of the cache, and clean old gem versions below
   const restoreKeys = [`${baseKey}-`]
@@ -246,7 +246,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
   return true
 }
 
-async function computeBaseKey(platform, engine, version, lockFile, cacheVersion) {
+async function computeBaseKey(engine, version, lockFile, cacheVersion) {
   const cwd = process.cwd()
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''


### PR DESCRIPTION
Following the pr https://github.com/ruby/setup-ruby/pull/473, instead of `platform`, `common.getOSNameVersionArch()` is used. This PR simplifies the Bundler cache key calculation by removing the platform variable from computeBaseKey.
