### PR TITLE
Remove `windows-2019` support and CI as such is no longer supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-13, macos-14, macos-15, windows-2019, windows-2022, windows-2025, windows-11-arm ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-13, macos-14, macos-15, windows-2022, windows-2025, windows-11-arm ]
         ruby: [
           '1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', ruby-head,
           jruby, jruby-head,
@@ -25,8 +25,6 @@ jobs:
           truffleruby+graalvm, truffleruby+graalvm-head
         ]
         include:
-        - { os: windows-2019, ruby: mingw }
-        - { os: windows-2019, ruby: mswin }
         - { os: windows-2022, ruby: mingw }
         - { os: windows-2022, ruby: mswin }
         - { os: windows-2022, ruby: ucrt  }
@@ -81,24 +79,19 @@ jobs:
         - { os: windows-11-arm, ruby: jruby }
         - { os: windows-11-arm, ruby: jruby-head }
         # RubyInstaller has no 64-bit builds of 1.9 on Windows
-        - { os: windows-2019, ruby: '1.9' }
         - { os: windows-2022, ruby: '1.9' }
         - { os: windows-2025, ruby: '1.9' }
         - { os: windows-11-arm, ruby: '1.9' }
         # TruffleRuby does not support Windows
-        - { os: windows-2019, ruby: truffleruby }
         - { os: windows-2022, ruby: truffleruby }
         - { os: windows-2025, ruby: truffleruby }
         - { os: windows-11-arm, ruby: truffleruby }
-        - { os: windows-2019, ruby: truffleruby-head }
         - { os: windows-2022, ruby: truffleruby-head }
         - { os: windows-2025, ruby: truffleruby-head }
         - { os: windows-11-arm, ruby: truffleruby-head }
-        - { os: windows-2019, ruby: truffleruby+graalvm }
         - { os: windows-2022, ruby: truffleruby+graalvm }
         - { os: windows-2025, ruby: truffleruby+graalvm }
         - { os: windows-11-arm, ruby: truffleruby+graalvm }
-        - { os: windows-2019, ruby: truffleruby+graalvm-head }
         - { os: windows-2022, ruby: truffleruby+graalvm-head }
         - { os: windows-2025, ruby: truffleruby+graalvm-head }
         - { os: windows-11-arm, ruby: truffleruby+graalvm-head }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The action works on these [GitHub-hosted runners](https://docs.github.com/en/act
 | ---------------- | --------- |
 | Ubuntu  | `ubuntu-22.04`, `ubuntu-24.04`, `ubuntu-22.04-arm`, `ubuntu-24.04-arm` |
 | macOS   | `macos-13` and newer versions |
-| Windows | `windows-2019`, `windows-2022`, `windows-2025`, `windows-11-arm` |
+| Windows | `windows-2022`, `windows-2025`, `windows-11-arm` |
 
 Not all combinations of runner images and versions are supported.
 The list of available Ruby versions can be seen in [ruby-builder-versions.json](ruby-builder-versions.json) for Ubuntu and macOS

--- a/common.js
+++ b/common.js
@@ -175,7 +175,6 @@ const GitHubHostedPlatforms = [
   'ubuntu-22.04-arm64',
   'ubuntu-24.04-x64',
   'ubuntu-24.04-arm64',
-  'windows-2019-x64',
   'windows-2022-x64',
   'windows-2025-x64',
   'windows-11-arm64'

--- a/dist/index.js
+++ b/dist/index.js
@@ -495,7 +495,6 @@ const GitHubHostedPlatforms = [
   'ubuntu-22.04-arm64',
   'ubuntu-24.04-x64',
   'ubuntu-24.04-arm64',
-  'windows-2019-x64',
   'windows-2022-x64',
   'windows-2025-x64',
   'windows-11-arm64'


### PR DESCRIPTION
I noticed in https://github.com/ruby/setup-ruby/pull/777 's CI run that this repo still supports and is trying to run `windows-2019` in CI, which is no longer supported. See [these logs](https://github.com/ruby/setup-ruby/actions/runs/16302159568/job/46039239937?pr=777) and below for reference. Thus, I'm proposing we remove support for and CI of `windows-2019`.

> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

From the issue linked above :point_up: 

> We will soon start the deprecation process for Windows 2019. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-06-01 and the image will be fully unsupported by 2025-06-30.