### PR TITLE
Add workaround for Ruby 3.1 after RubyGems 3.7.0 release

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -137,9 +137,8 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
   }
 
   const gem = path.join(rubyPrefix, 'bin', 'gem')
-  // Workaround for https://github.com/rubygems/rubygems/issues/5245
   // and for https://github.com/oracle/truffleruby/issues/2780
-  const force = ((platform.startsWith('windows-') && engine === 'ruby' && floatVersion >= 3.1) || (engine === 'truffleruby')) ? ['--force'] : []
+  const force = engine === 'truffleruby' ? ['--force'] : []
 
   const versionParts = [...bundlerVersion.matchAll(/\d+/g)].length
   const bundlerVersionConstraint = versionParts >= 3 ? bundlerVersion : `~> ${bundlerVersion}.0`

--- a/bundler.js
+++ b/bundler.js
@@ -137,13 +137,11 @@ export async function installBundler(bundlerVersionInput, rubygemsInputSet, lock
   }
 
   const gem = path.join(rubyPrefix, 'bin', 'gem')
-  // and for https://github.com/oracle/truffleruby/issues/2780
-  const force = engine === 'truffleruby' ? ['--force'] : []
 
   const versionParts = [...bundlerVersion.matchAll(/\d+/g)].length
   const bundlerVersionConstraint = versionParts >= 3 ? bundlerVersion : `~> ${bundlerVersion}.0`
 
-  await exec.exec(gem, ['install', 'bundler', ...force, '-v', bundlerVersionConstraint])
+  await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint])
 
   return bundlerVersion
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -71454,8 +71454,10 @@ async function rubygemsLatest(gem, platform, engine, rubyVersion) {
     const floatVersion = common.floatVersion(rubyVersion)
     if (common.isHeadVersion(rubyVersion)) {
       console.log('Ruby master builds use included RubyGems')
-    } else if (floatVersion >= 3.1) {
+    } else if (floatVersion >= 3.2) {
       await exec.exec(gem, ['update', '--system'])
+    } else if (floatVersion >= 3.1) {
+      await exec.exec(gem, ['update', '--system', '3.6.9'])
     } else if (floatVersion >= 3.0) {
       await exec.exec(gem, ['update', '--system', '3.5.23'])
     } else if (floatVersion >= 2.6) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -151,13 +151,11 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
   }
 
   const gem = path.join(rubyPrefix, 'bin', 'gem')
-  // and for https://github.com/oracle/truffleruby/issues/2780
-  const force = engine === 'truffleruby' ? ['--force'] : []
 
   const versionParts = [...bundlerVersion.matchAll(/\d+/g)].length
   const bundlerVersionConstraint = versionParts >= 3 ? bundlerVersion : `~> ${bundlerVersion}.0`
 
-  await exec.exec(gem, ['install', 'bundler', ...force, '-v', bundlerVersionConstraint])
+  await exec.exec(gem, ['install', 'bundler', '-v', bundlerVersionConstraint])
 
   return bundlerVersion
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -151,9 +151,8 @@ async function installBundler(bundlerVersionInput, rubygemsInputSet, lockFile, p
   }
 
   const gem = path.join(rubyPrefix, 'bin', 'gem')
-  // Workaround for https://github.com/rubygems/rubygems/issues/5245
   // and for https://github.com/oracle/truffleruby/issues/2780
-  const force = ((platform.startsWith('windows-') && engine === 'ruby' && floatVersion >= 3.1) || (engine === 'truffleruby')) ? ['--force'] : []
+  const force = engine === 'truffleruby' ? ['--force'] : []
 
   const versionParts = [...bundlerVersion.matchAll(/\d+/g)].length
   const bundlerVersionConstraint = versionParts >= 3 ? bundlerVersion : `~> ${bundlerVersion}.0`

--- a/rubygems.js
+++ b/rubygems.js
@@ -39,8 +39,10 @@ async function rubygemsLatest(gem, platform, engine, rubyVersion) {
     const floatVersion = common.floatVersion(rubyVersion)
     if (common.isHeadVersion(rubyVersion)) {
       console.log('Ruby master builds use included RubyGems')
-    } else if (floatVersion >= 3.1) {
+    } else if (floatVersion >= 3.2) {
       await exec.exec(gem, ['update', '--system'])
+    } else if (floatVersion >= 3.1) {
+      await exec.exec(gem, ['update', '--system', '3.6.9'])
     } else if (floatVersion >= 3.0) {
       await exec.exec(gem, ['update', '--system', '3.5.23'])
     } else if (floatVersion >= 2.6) {


### PR DESCRIPTION
Like every time I release a version of RubyGems dropping support for a EOL Ruby, I forgot to update `ruby/setup-ruby` before the release, so that `rubygems: latest` does not break 😅

Fixing it now.

This issue was fixed by https://github.com/rubygems/rubygems/pull/7334, shipped with RubyGems 3.5.4. That version of RubyGems comes by default with Ruby 3.3.1 or higher, so I believe we just need one more future update similar to this one right before shipping a RubyGems version dropping support for Ruby 3.2. I will try to remember that one last time!