### PR TITLE
Add printing of the lockfile after installation (retry)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,18 @@ jobs:
           ruby-version: '2.6'
       - run: ruby -v
 
+  testNoGemfileWithBundlerCache:
+    name: "Test with no Gemfile but with bundler-cache"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rm Gemfile
+      - uses: ./
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      - run: ruby -v
+
   testLatestRubygemsVersion:
     name: "Test rubygems: latest on ${{ matrix.ruby }}"
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -85351,7 +85351,7 @@ async function setupRuby(options = {}) {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
 
-    if (fs.existsSync(lockFile)) {
+    if (lockFile !== null && fs.existsSync(lockFile)) {
       await core.group(`Print lockfile`, async () =>
         await exec.exec('cat', [lockFile]))
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -85350,6 +85350,11 @@ async function setupRuby(options = {}) {
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
+
+    if (fs.existsSync(lockFile)) {
+      await core.group(`Print lockfile`, async () =>
+        await exec.exec('cat', [lockFile]))
+    }
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)

--- a/index.js
+++ b/index.js
@@ -99,6 +99,11 @@ export async function setupRuby(options = {}) {
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
+
+    if (fs.existsSync(lockFile)) {
+      await core.group(`Print lockfile`, async () =>
+        await exec.exec('cat', [lockFile]))
+    }
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ export async function setupRuby(options = {}) {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
 
-    if (fs.existsSync(lockFile)) {
+    if (lockFile !== null && fs.existsSync(lockFile)) {
       await core.group(`Print lockfile`, async () =>
         await exec.exec('cat', [lockFile]))
     }


### PR DESCRIPTION
Reimplementation of #785, but with checking the case of a missing lockfile (caused by a missing Gemfile).

While the case of user `bundler-cache: true` with a missing Gemfile is strange, it is something that was working prior to #785.

Closes #783

@eregon Please review.