### PR TITLE
Print lockfile contents earlier

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -165,6 +165,9 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
     await exec.exec('bundle', ['lock'], envOptions)
   }
 
+  await core.group(`Print lockfile`, async () =>
+    await exec.exec('cat', [lockFile]))
+
   // cache key
   const paths = [cachePath]
   const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)

--- a/dist/index.js
+++ b/dist/index.js
@@ -179,6 +179,9 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
     await exec.exec('bundle', ['lock'], envOptions)
   }
 
+  await core.group(`Print lockfile`, async () =>
+    await exec.exec('cat', [lockFile]))
+
   // cache key
   const paths = [cachePath]
   const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)
@@ -85343,11 +85346,6 @@ async function setupRuby(options = {}) {
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
-
-    if (lockFile !== null && fs.existsSync(lockFile)) {
-      await core.group(`Print lockfile`, async () =>
-        await exec.exec('cat', [lockFile]))
-    }
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)

--- a/index.js
+++ b/index.js
@@ -99,11 +99,6 @@ export async function setupRuby(options = {}) {
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
       bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
-
-    if (lockFile !== null && fs.existsSync(lockFile)) {
-      await core.group(`Print lockfile`, async () =>
-        await exec.exec('cat', [lockFile]))
-    }
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)


### PR DESCRIPTION
Currently, the lockfile gets printed after `bundle install` finished. This could be too late when `bundle install` fails for whatever reason.

I have a workflow that failed like this:

<details><summary>Logs</summary>
<p>

```

55s
Run ruby/setup-ruby@v1
Modifying PATH
Downloading Ruby
Extracting  Ruby
Print Ruby version
Installing Bundler
> bundle install
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle config --local path /home/runner/work/rubocop/rubocop/vendor/bundle
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle lock
Fetching source index from https://rubygems.org/
Network error while fetching
https://rubygems.org/quick/Marshal.4.8/asciidoctor-0.0.1.gemspec.rz (Connection
reset by peer - SSL_connect)
Error: The process '/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle' failed with exit code 17
Run ruby/setup-ruby@v1
Modifying PATH
Downloading Ruby
Extracting  Ruby
Print Ruby version
Installing Bundler
> bundle install
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle config --local path /home/runner/work/rubocop/rubocop/vendor/bundle
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle lock
Fetching source index from https://rubygems.org/
Network error while fetching
https://rubygems.org/quick/Marshal.4.8/asciidoctor-0.0.1.gemspec.rz (Connection
reset by peer - SSL_connect)
Error: The process '/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle' failed with exit code 17
```

</p>
</details> 

It would help to print the lockfile for this I think. It fetching version 0.0.1 confused me but probably the lockfile looks ok. New output:

```
Run ./
Modifying PATH
Print Ruby version
Installing Bundler
> bundle install
/opt/hostedtoolcache/Ruby/3.2.9/x64/bin/bundle config --local path /home/runner/work/setup-ruby/setup-ruby/vendor/bundle
/opt/hostedtoolcache/Ruby/3.2.9/x64/bin/bundle lock
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Writing lockfile to /home/runner/work/setup-ruby/setup-ruby/gemfiles/rails8.gemfile.lock
Print lockfile
Cache key: setup-ruby-bundler-cache-v6-ubuntu-24.04-x64-ruby-3.2.9-wd-/home/runner/work/setup-ruby/setup-ruby-with--without--only--/home/runner/work/setup-ruby/setup-ruby/gemfiles/rails8.gemfile.lock-cb69172094f71f01e5207070d9af8d465d9aa9c386ecbad22b1b6e8e43523fd2
/opt/hostedtoolcache/Ruby/3.2.9/x64/bin/bundle install --jobs 4
...
```

So it's relatively at the top and not hidden somewhere. Also removes the need to check for the lockfile again.