### PR TITLE
Skip saving cache for merge_group event

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -218,7 +218,8 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   await exec.exec('bundle', ['install', '--jobs', `${jobs}`])
 
   // @actions/cache only allows to save for non-existing keys
-  if (!common.isExactCacheKeyMatch(key, cachedKey)) {
+  // Also, skip saving cache for merge_group event
+  if (!common.isExactCacheKeyMatch(key, cachedKey) && process.env['GITHUB_EVENT_NAME'] !== 'merge_group') {
     if (cachedKey) { // existing cache but Gemfile.lock differs, clean old gems
       await exec.exec('bundle', ['clean'])
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -232,7 +232,8 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
   await exec.exec('bundle', ['install', '--jobs', `${jobs}`])
 
   // @actions/cache only allows to save for non-existing keys
-  if (!common.isExactCacheKeyMatch(key, cachedKey)) {
+  // Also, skip saving cache for merge_group event
+  if (!common.isExactCacheKeyMatch(key, cachedKey) && process.env['GITHUB_EVENT_NAME'] !== 'merge_group') {
     if (cachedKey) { // existing cache but Gemfile.lock differs, clean old gems
       await exec.exec('bundle', ['clean'])
     }


### PR DESCRIPTION
- Closes #805

Note, I did not do `yarn update` in order to keep the lockfile change small. This has introduced some transitive dependencies at different versions. One of the maintainers should probably do a dependency update at some point. 