### PR TITLE
Scale bundler install jobs with CPU count up to 8

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -197,7 +197,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   // Number of jobs should scale with runner, up to a point
   const jobs = Math.min(os.availableParallelism(), 8)
   // Always run 'bundle install' to list the gems
-  await exec.exec('bundle', ['install', '--jobs', jobs])
+  await exec.exec('bundle', ['install', '--jobs', `${jobs}`])
 
   // @actions/cache only allows to save for non-existing keys
   if (!common.isExactCacheKeyMatch(key, cachedKey)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -211,7 +211,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
   // Number of jobs should scale with runner, up to a point
   const jobs = Math.min(os.availableParallelism(), 8)
   // Always run 'bundle install' to list the gems
-  await exec.exec('bundle', ['install', '--jobs', jobs])
+  await exec.exec('bundle', ['install', '--jobs', `${jobs}`])
 
   // @actions/cache only allows to save for non-existing keys
   if (!common.isExactCacheKeyMatch(key, cachedKey)) {


### PR DESCRIPTION
The number of jobs should scale with the runner CPU count, up to a point. The bottleneck becomes network / disk I/O at very large numbers, and 8 seems like a reasonable maximum based on my experience at this time.

Many of the private repos that I work on use runners with GitHub-hosted runners with only 2 cores, and oversubscribing there can actually lead to slower runs.