### PR TITLE
Add restriction and validation for download urls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,6 +370,7 @@ jobs:
         run: ruby -e "abort if File.exist?('C:/msys64/mingw64/bin/gcc.exe')"
 
   validate-windows-versions:
+    name: "Check windows*versions.json are up-to-date"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -380,7 +381,8 @@ jobs:
     - name: Check generated files are up to date
       run: git diff --exit-code
 
-  lint:
+  check-dist-index:
+    name: "Check dist/index.js is up-to-date"
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,6 +369,17 @@ jobs:
       - name: C:/msys64/mingw64/bin/gcc.exe not installed
         run: ruby -e "abort if File.exist?('C:/msys64/mingw64/bin/gcc.exe')"
 
+  validate-windows-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./
+      with:
+        ruby-version: ruby
+    - run: ruby generate-windows-versions.rb
+    - name: Check generated files are up to date
+      run: git diff --exit-code
+
   lint:
     runs-on: ubuntu-22.04
     steps:

--- a/generate-windows-versions.rb
+++ b/generate-windows-versions.rb
@@ -4,18 +4,18 @@ require 'json'
 
 # General rules:
 # - All the static parts of the expected URL are checked literally.
-# - Don't forget to escape dot (`.`) and other special characters when used literally.
 # - Each path component must begin with [\w], or a more restrictive character set.
 # - Percent (`%`) shall not be allowed to avoid any percent encoding.
 WINDOWS_VERSIONS_URLS_REGEXPS = [
-  %r{\Ahttps://github\.com/oneclick/rubyinstaller2?/releases/download/\w[\w.-]*/\w[\w.-]*\z},
-  %r{\Ahttps://github\.com/MSP-Greg/ruby-loco/releases/download/\w[\w.-]*/\w[\w.-]*\z}
+  %r{\A#{Regexp.escape 'https://github.com/oneclick/rubyinstaller/releases/download'}/\w[\w.-]*/\w[\w.-]*\z},
+  %r{\A#{Regexp.escape 'https://github.com/oneclick/rubyinstaller2/releases/download'}/\w[\w.-]*/\w[\w.-]*\z},
+  %r{\A#{Regexp.escape 'https://github.com/MSP-Greg/ruby-loco/releases/download'}/\w[\w.-]*/\w[\w.-]*\z}
 ].freeze
 
 WINDOWS_TOOLCHAIN_VERSIONS_URLS_REGEXPS = [
-  %r{\Ahttps://github\.com/oneclick/rubyinstaller/releases/download/devkit-4\.7\.2/DevKit-mingw64-64-4\.7\.2-20130224-1432-sfx\.exe\z},
-  %r{\Ahttps://github\.com/ruby/setup-msys2-gcc/releases/download/\w[\w.-]*/\w[\w@.-]*\z},
-  %r{\Ahttps://github\.com/ruby/setup-msys2-gcc/releases/latest/download/\w[\w@.-]*\z}
+  %r{\A#{Regexp.escape 'https://github.com/oneclick/rubyinstaller/releases/download/devkit-4.7.2/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe'}\z},
+  %r{\A#{Regexp.escape 'https://github.com/ruby/setup-msys2-gcc/releases/download'}/\w[\w.-]*/\w[\w@.-]*\z},
+  %r{\A#{Regexp.escape 'https://github.com/ruby/setup-msys2-gcc/releases/latest/download'}/\w[\w@.-]*\z}
 ].freeze
 
 # Validate all the URLs in the versions json

--- a/generate-windows-versions.rb
+++ b/generate-windows-versions.rb
@@ -2,6 +2,31 @@ require 'open-uri'
 require 'yaml'
 require 'json'
 
+# General rules:
+# - All the static parts of the expected URL are checked literally.
+# - Don't forget to escape dot (`.`) and other special characters when used literally.
+# - Each path component must begin with [\w], or a more restrictive character set.
+# - Percent (`%`) shall not be allowed to avoid any percent encoding.
+WINDOWS_VERSIONS_URLS_REGEXPS = [
+  %r{^https://github\.com/oneclick/rubyinstaller2?/releases/download/\w[\w.-]*/\w[\w.-]*$},
+  %r{^https://github\.com/MSP-Greg/ruby-loco/releases/download/\w[\w.-]*/\w[\w.-]*$}
+].freeze
+
+WINDOWS_TOOLCHAIN_VERSIONS_URLS_REGEXPS = [
+  %r{^https://github\.com/oneclick/rubyinstaller/releases/download/devkit-4\.7\.2/DevKit-mingw64-64-4\.7\.2-20130224-1432-sfx\.exe$},
+  %r{^https://github\.com/ruby/setup-msys2-gcc/releases/download/\w[\w.-]*/\w[\w@.-]*$},
+  %r{^https://github\.com/ruby/setup-msys2-gcc/releases/latest/download/\w[\w@.-]*$}
+].freeze
+
+# Validate all the URLs in the versions json
+def validate(versions, allowed_urls_regexps)
+  versions.values.flat_map(&:values).each do |url|
+    if allowed_urls_regexps.none? { |regexp| regexp =~ url }
+      raise SecurityError, "Unexpected URL: #{url}"
+    end
+  end
+end
+
 min_requirements = ['~> 2.0.0', '~> 2.1.9', '>= 2.2.6'].map { |req| Gem::Requirement.new(req) }
 
 url = 'https://raw.githubusercontent.com/oneclick/rubyinstaller.org-website/master/_data/downloads.yaml'
@@ -48,6 +73,7 @@ versions['ucrt'] = {
   'x64' => 'https://github.com/MSP-Greg/ruby-loco/releases/download/ruby-master/ruby-ucrt.7z'
 }
 
+validate(versions, WINDOWS_VERSIONS_URLS_REGEXPS)
 File.binwrite 'windows-versions.json', "#{JSON.pretty_generate(versions)}\n"
 
 base_url = 'https://github.com/ruby/setup-msys2-gcc/releases/latest/download/windows-toolchain.json'
@@ -90,4 +116,5 @@ versions.each do |raw_version, archs|
   end
 end
 
+validate(versions, WINDOWS_TOOLCHAIN_VERSIONS_URLS_REGEXPS)
 File.binwrite 'windows-toolchain-versions.json', "#{JSON.pretty_generate(versions)}\n"

--- a/generate-windows-versions.rb
+++ b/generate-windows-versions.rb
@@ -8,20 +8,20 @@ require 'json'
 # - Each path component must begin with [\w], or a more restrictive character set.
 # - Percent (`%`) shall not be allowed to avoid any percent encoding.
 WINDOWS_VERSIONS_URLS_REGEXPS = [
-  %r{^https://github\.com/oneclick/rubyinstaller2?/releases/download/\w[\w.-]*/\w[\w.-]*$},
-  %r{^https://github\.com/MSP-Greg/ruby-loco/releases/download/\w[\w.-]*/\w[\w.-]*$}
+  %r{\Ahttps://github\.com/oneclick/rubyinstaller2?/releases/download/\w[\w.-]*/\w[\w.-]*\z},
+  %r{\Ahttps://github\.com/MSP-Greg/ruby-loco/releases/download/\w[\w.-]*/\w[\w.-]*\z}
 ].freeze
 
 WINDOWS_TOOLCHAIN_VERSIONS_URLS_REGEXPS = [
-  %r{^https://github\.com/oneclick/rubyinstaller/releases/download/devkit-4\.7\.2/DevKit-mingw64-64-4\.7\.2-20130224-1432-sfx\.exe$},
-  %r{^https://github\.com/ruby/setup-msys2-gcc/releases/download/\w[\w.-]*/\w[\w@.-]*$},
-  %r{^https://github\.com/ruby/setup-msys2-gcc/releases/latest/download/\w[\w@.-]*$}
+  %r{\Ahttps://github\.com/oneclick/rubyinstaller/releases/download/devkit-4\.7\.2/DevKit-mingw64-64-4\.7\.2-20130224-1432-sfx\.exe\z},
+  %r{\Ahttps://github\.com/ruby/setup-msys2-gcc/releases/download/\w[\w.-]*/\w[\w@.-]*\z},
+  %r{\Ahttps://github\.com/ruby/setup-msys2-gcc/releases/latest/download/\w[\w@.-]*\z}
 ].freeze
 
 # Validate all the URLs in the versions json
 def validate(versions, allowed_urls_regexps)
   versions.values.flat_map(&:values).each do |url|
-    if allowed_urls_regexps.none? { |regexp| regexp =~ url }
+    if allowed_urls_regexps.none? { |regexp| regexp.match? url }
       raise SecurityError, "Unexpected URL: #{url}"
     end
   end


### PR DESCRIPTION
This PR takes a slightly different approach to the URL safety guardrail discussed in #848:

1. It adds the check into directly `generate-windows-version.rb` in the first place so hopefully we can make sure the bot generated PR are clean. - The possibility of tempering `generate-windows-version.rb` itself shall be guard via checking files that has been updated by bot PR. 
2. The `generate-windows-version.rb` added to run as part of the normal CI as well, and the output is compared with checked-in version, to make sure avoid the case where bot is compromised and the windows versions files are tempered without modifying `generate-windows-version.rb` (of course, hacker first need gain access to other repos to upload compromised artifacts).

This might introduce a little bit noise if a new RI2 release has been released but has not been added here yet, and around the same time someone tries to contribute other changes. I think that's going to be extremely rare, and it's not a huge issue anyways.