### PR TITLE
add hook for setup script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
       For 'latest', `gem update --system` is run to update to the latest compatible RubyGems version.
       Ruby head/master builds will not be updated.
       Similarly, if a version number is given, `gem update --system <version>` is run to update to that version of RubyGems, as long as that version is newer than the one provided by default.
+  setup-script:
+    description: |
+      Setup code to be executed after Ruby and Bundler are installed, but before `bundle install` is run.
+      If you want to execute a script on disk, just pass the filename, like `'./setup.sh'` or `'ruby setup.rb'`
+      If you intend to use this to install a custom Bundler version or the like, make sure to specify `bundler: none`.
   bundler:
     description: |
       The version of Bundler to install. Either 'Gemfile.lock' (the default), 'default', 'latest', 'none', or a version number (e.g., 1, 2, 2.1, 2.1.4).

--- a/dist/index.js
+++ b/dist/index.js
@@ -92443,6 +92443,7 @@ const inputDefaults = {
   'rubygems': 'default',
   'bundler': 'Gemfile.lock',
   'bundler-cache': 'false',
+  'setup-script': '',
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
   'self-hosted': 'false',
@@ -92525,6 +92526,15 @@ async function setupRuby(options = {}) {
   if (inputs['bundler'] !== 'none') {
     bundlerVersion = await common.measure('Installing Bundler', async () =>
       bundler.installBundler(inputs['bundler'], rubygemsInputSet, lockFile, platform, rubyPrefix, engine, version))
+  }
+
+  if (inputs['setup-script'] !== '') {
+    await common.measure('Running setup script', async () => {
+      const lines = inputs['setup-script'].split(/\r?\n/)
+      for (const line of lines) {
+        await exec.exec(line)
+      }
+    })
   }
 
   if (inputs['bundler-cache'] === 'true') {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const inputDefaults = {
   'rubygems': 'default',
   'bundler': 'Gemfile.lock',
   'bundler-cache': 'false',
+  'setup-script': '',
   'working-directory': '.',
   'cache-version': bundler.DEFAULT_CACHE_VERSION,
   'self-hosted': 'false',
@@ -96,6 +97,15 @@ export async function setupRuby(options = {}) {
   if (inputs['bundler'] !== 'none') {
     bundlerVersion = await common.measure('Installing Bundler', async () =>
       bundler.installBundler(inputs['bundler'], rubygemsInputSet, lockFile, platform, rubyPrefix, engine, version))
+  }
+
+  if (inputs['setup-script'] !== '') {
+    await common.measure('Running setup script', async () => {
+      const lines = inputs['setup-script'].split(/\r?\n/)
+      for (const line of lines) {
+        await exec.exec(line)
+      }
+    })
   }
 
   if (inputs['bundler-cache'] === 'true') {


### PR DESCRIPTION
This gives you the ability to pass script text to the `setup-ruby` action. The script will be executed after Ruby and Bundler are installed, but before `bundle install` is run.

This lets you install packages or Bundler plugins, download patches, anything.

If you want to execute a script on disk, just pass the filename, like `'./setup.sh'` or `'ruby setup.rb'`

If you intend to use this to install a custom Bundler version or the like, make sure to specify `bundler: none` so you don't get a second version installed.