### PR TITLE
Move check-new-windows-versions.yml workflow from ruby/ruby-builder to ruby/setup-ruby

### DIFF
--- a/.github/workflows/check-new-windows-versions.yml
+++ b/.github/workflows/check-new-windows-versions.yml
@@ -1,0 +1,46 @@
+name: Check for new CRuby releases on Windows
+on:
+  schedule:
+  - cron: '0 7,19 * * *'
+  workflow_dispatch:
+
+jobs:
+  check_windows_versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - run: ruby generate-windows-versions.rb
+
+    - name: TODO for testing
+      run: echo >> windows-versions.json
+
+    - id: diff
+      run: git diff --exit-code
+      continue-on-error: true
+
+    - if: ${{ steps.diff.outcome == 'failure' }} # changed
+      run: ./pre-commit
+      shell: bash
+
+    # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork
+    - if: ${{ steps.diff.outcome == 'failure' }} # changed
+      uses: peter-evans/create-pull-request@v8
+      id: pr
+      with:
+        push-to-fork: ruby-builder-bot/setup-ruby
+        author: ruby-builder-bot <98265520+ruby-builder-bot@users.noreply.github.com>
+        committer: ruby-builder-bot <98265520+ruby-builder-bot@users.noreply.github.com>
+        title: Update CRuby releases on Windows
+        commit-message: Update CRuby releases on Windows
+        body: Automated PR (testing)
+        branch: windows
+        delete-branch: true
+        token: ${{ secrets.PR_FROM_RUBY_BUILDER_TOKEN }}
+
+    - if: ${{ steps.diff.outcome == 'failure' }} # changed
+      name: PR URL
+      run: echo "${{ steps.pr.outputs.pull-request-url }}"
+      shell: bash


### PR DESCRIPTION
GitHub Actions itself cannot create PRs: https://github.com/ruby/setup-ruby/actions/runs/21594580921/job/62223395927?pr=870
So we need an explicit PR author.

ruby/ruby-builder@5c81c6466da5247c8f1ef9e347aec1108ff20796