### PR TITLE
INFR-258 Add support for Windows Server Standard Evaluation

### DIFF
--- a/common.js
+++ b/common.js
@@ -281,7 +281,7 @@ export function getOSNameVersionArch() {
 
 function findWindowsVersion() {
   const version = os.version()
-  const match = version.match(/^Windows(?: Server)? (\d+) (?:Datacenter|Enterprise)/)
+  const match = version.match(/^Windows(?: Server)? (\d+) (?:Standard|Datacenter|Enterprise)/)
   if (match) {
     return match[1]
   } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -614,7 +614,7 @@ function getOSNameVersionArch() {
 
 function findWindowsVersion() {
   const version = os.version()
-  const match = version.match(/^Windows(?: Server)? (\d+) (?:Datacenter|Enterprise)/)
+  const match = version.match(/^Windows(?: Server)? (\d+) (?:Standard|Datacenter|Enterprise)/)
   if (match) {
     return match[1]
   } else {


### PR DESCRIPTION
blacksmith.sh runners use "Windows Server 2025 Standard Evaluation".