### PR TITLE
Allow customising project ID in cache key rather than it always including working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ It is also possible to cache gems manually, but this is not recommended because 
 There are many concerns which means using `actions/cache` is never enough for caching gems (e.g., incomplete cache key, cleaning old gems when restoring from another key, correctly hashing the lockfile if not checked in, OS versions, ABI compatibility for `ruby-head`, etc).
 So, please use `bundler-cache: true` instead and report any issue.
 
+#### Caching with an ephemeral working directory
+
+A runner could be set up to use an ephemeral working directory per build, e.g. `/codebuild/output/src3500696690/src/actions-runner/_work/my-project`.
+By default, the cache key includes the full working directory path; but for an ephemeral working directory, it wouldn't produce the same key across runs, resulting in an inability to restore from the cache.
+To resolve this, set the `project-id` option to a name to identify your project. When provided, this is used instead of the working directory path in the cache key.
+
+```yaml
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        project-id: my-project
+```
+
 ### Authentication Token
 
 By default, this action uses `${{ github.token }}` to authenticate when downloading Ruby release assets from GitHub.

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
       When running this action on github.com, the default value is sufficient.
       When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  project-id:
+    description: |
+      A name to identify your project, for inclusion in the Bundler cache key instead of the full working directory path.
+      Useful when your runner is set up to use an ephemeral working directory per build.
 
 outputs:
   ruby-prefix:

--- a/bundler.js
+++ b/bundler.js
@@ -155,7 +155,7 @@ function bundlerConfigSetArgs(bundlerVersion, key, value) {
   }
 }
 
-export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, bundlerVersion, cacheVersion) {
+export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, bundlerVersion, cacheVersion, projectId) {
   if (gemfile === null) {
     console.log('Could not determine gemfile path, skipping "bundle install" and caching')
     return false
@@ -189,7 +189,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
 
   // cache key
   const paths = [cachePath]
-  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)
+  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion, projectId)
   const key = `${baseKey}-${await common.hashFile(lockFile)}`
   // If only Gemfile.lock changes we can reuse part of the cache, and clean old gem versions below
   const restoreKeys = [`${baseKey}-`]
@@ -242,12 +242,12 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
   return true
 }
 
-async function computeBaseKey(engine, version, lockFile, cacheVersion) {
-  const cwd = process.cwd()
+async function computeBaseKey(engine, version, lockFile, cacheVersion, specifiedProjectId) {
+  const projectId = specifiedProjectId || `wd-${process.cwd()}`
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''
   const bundleOnly = process.env['BUNDLE_ONLY'] || ''
-  let key = `setup-ruby-bundler-cache-v6-${common.getOSNameVersionArch()}-${engine}-${version}-wd-${cwd}-with-${bundleWith}-without-${bundleWithout}-only-${bundleOnly}`
+  let key = `setup-ruby-bundler-cache-v6-${common.getOSNameVersionArch()}-${engine}-${version}-${projectId}-with-${bundleWith}-without-${bundleWithout}-only-${bundleOnly}`
 
   if (cacheVersion !== DEFAULT_CACHE_VERSION) {
     key += `-v-${cacheVersion}`

--- a/dist/index.js
+++ b/dist/index.js
@@ -169,7 +169,7 @@ function bundlerConfigSetArgs(bundlerVersion, key, value) {
   }
 }
 
-async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, bundlerVersion, cacheVersion) {
+async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, bundlerVersion, cacheVersion, projectId) {
   if (gemfile === null) {
     console.log('Could not determine gemfile path, skipping "bundle install" and caching')
     return false
@@ -203,7 +203,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
 
   // cache key
   const paths = [cachePath]
-  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion)
+  const baseKey = await computeBaseKey(engine, rubyVersion, lockFile, cacheVersion, projectId)
   const key = `${baseKey}-${await common.hashFile(lockFile)}`
   // If only Gemfile.lock changes we can reuse part of the cache, and clean old gem versions below
   const restoreKeys = [`${baseKey}-`]
@@ -256,12 +256,12 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
   return true
 }
 
-async function computeBaseKey(engine, version, lockFile, cacheVersion) {
-  const cwd = process.cwd()
+async function computeBaseKey(engine, version, lockFile, cacheVersion, specifiedProjectId) {
+  const projectId = specifiedProjectId || `wd-${process.cwd()}`
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''
   const bundleOnly = process.env['BUNDLE_ONLY'] || ''
-  let key = `setup-ruby-bundler-cache-v6-${common.getOSNameVersionArch()}-${engine}-${version}-wd-${cwd}-with-${bundleWith}-without-${bundleWithout}-only-${bundleOnly}`
+  let key = `setup-ruby-bundler-cache-v6-${common.getOSNameVersionArch()}-${engine}-${version}-${projectId}-with-${bundleWith}-without-${bundleWithout}-only-${bundleOnly}`
 
   if (cacheVersion !== DEFAULT_CACHE_VERSION) {
     key += `-v-${cacheVersion}`
@@ -92506,6 +92506,7 @@ const inputDefaults = {
   'self-hosted': 'false',
   'windows-toolchain': 'default',
   'token': '',
+  'project-id': null,
 }
 
 // entry point when this action is run on its own
@@ -92587,7 +92588,7 @@ async function setupRuby(options = {}) {
 
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
-      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
+      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version'], inputs['project-id']))
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const inputDefaults = {
   'self-hosted': 'false',
   'windows-toolchain': 'default',
   'token': '',
+  'project-id': null,
 }
 
 // entry point when this action is run on its own
@@ -100,7 +101,7 @@ export async function setupRuby(options = {}) {
 
   if (inputs['bundler-cache'] === 'true') {
     await common.time('bundle install', async () =>
-      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version']))
+      bundler.bundleInstall(gemfile, lockFile, platform, engine, version, bundlerVersion, inputs['cache-version'], inputs['project-id']))
   }
 
   core.setOutput('ruby-prefix', rubyPrefix)


### PR DESCRIPTION
Resolves https://github.com/ruby/setup-ruby/issues/904

I decided to go with something simple rather than using the Git repo remote URL which I'd first thought to use. The URL might not suit all use-cases - perhaps someone has multiple bundles in the one repo (hence you having added the workdir to distinguish). Instead, a simple customisable string value `project-id` would allow using the action multiple times in a job for different directories with a different `project-id`.

## Testing

Tested and working in our GitHub Actions workflow using:

```yaml
      # Fork of ruby/setup-ruby to support ephemeral workdir
      - uses: ZimbiX/setup-ruby@remove-pwd-from-bundler-cache-key
        with:
          ruby-version: 3.3.6
          bundler-cache: true
          project-id: better_caring
```

Logs:

```
Cache key: setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.3.6-better_caring-with--without--only--Gemfile.lock-3f96ad38961e7a44e242400b976a8833512d7d013bd35c5f24b09672d2fd2667
Cache hit for: setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.3.6-better_caring-with--without--only--Gemfile.lock-3f96ad38961e7a44e242400b976a8833512d7d013bd35c5f24b09672d2fd2667
Received 0 of 140644053 (0.0%), 0.0 MBs/sec
Received 0 of 140644053 (0.0%), 0.0 MBs/sec
Received 8388608 of 140644053 (6.0%), 2.7 MBs/sec
Received 46137344 of 140644053 (32.8%), 11.0 MBs/sec
Received 100663296 of 140644053 (71.6%), 19.2 MBs/sec
Received 136449749 of 140644053 (97.0%), 21.7 MBs/sec
Received 140644053 of 140644053 (100.0%), 20.8 MBs/sec
Cache Size: ~134 MB (140644053 B)
/usr/bin/tar -xf /codebuild/output/src2839699089/src/actions-runner/_work/_temp/e8390f69-4590-46ba-aa6f-789b62f5e608/cache.tzst -P -C /codebuild/output/src2839699089/src/actions-runner/_work/better_caring/better_caring --use-compress-program unzstd
Cache restored successfully
Found cache for key: setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.3.6-better_caring-with--without--only--Gemfile.lock-3f96ad38961e7a44e242400b976a8833512d7d013bd35c5f24b09672d2fd2667
```