### PR TITLE
Use relative path in cache key

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -243,7 +243,7 @@ export async function bundleInstall(gemfile, lockFile, platform, engine, rubyVer
 }
 
 async function computeBaseKey(engine, version, lockFile, cacheVersion) {
-  const cwd = process.cwd()
+  const cwd = process.cwd().startsWith(process.env.GITHUB_WORKSPACE) ? path.relative(process.env.GITHUB_WORKSPACE, process.cwd()) : process.cwd()
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''
   const bundleOnly = process.env['BUNDLE_ONLY'] || ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -257,7 +257,7 @@ async function bundleInstall(gemfile, lockFile, platform, engine, rubyVersion, b
 }
 
 async function computeBaseKey(engine, version, lockFile, cacheVersion) {
-  const cwd = process.cwd()
+  const cwd = process.cwd().startsWith(process.env.GITHUB_WORKSPACE) ? path.relative(process.env.GITHUB_WORKSPACE, process.cwd()) : process.cwd()
   const bundleWith = process.env['BUNDLE_WITH'] || ''
   const bundleWithout = process.env['BUNDLE_WITHOUT'] || ''
   const bundleOnly = process.env['BUNDLE_ONLY'] || ''


### PR DESCRIPTION
This is an alternative solution to the issue described in #904 and #905.

The problem statement is that when use aws codebuild as self-hosted runner, the `$GITHUB_WORKSPACE` would change on every single build, and currently the cache key contains `process.cwd()`, thus it will always invalidate the cache.

The solution in this PR is to use a relative cwd computed from `$GITHUB_WORKSPACE` instead of the absolute cwd, so that it works consistently on github runner and other runners.

Note: This change will invalidate all caches on all repositories once when updating to this version due to updating the cache key, but after that cache should work again.

- Fixes #904
- Closes #905 
 