### PR TITLE
Update README: fix outdated URLs and Ruby version examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ jobs:
 ```
 
 See the GitHub Actions documentation for more details about the
-[workflow syntax](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions)
-and the [condition and expression syntax](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions).
+[workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
+and the [condition and expression syntax](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions).
 
 ### Supported Version Syntax
 
@@ -252,7 +252,7 @@ Note that running CI on Windows can be quite challenging if you are not very fam
 It is recommended to first get your build working on Ubuntu and macOS before trying Windows.
 
 * Use Bundler 2.2.18+ on Windows (older versions have [bugs](https://github.com/ruby/setup-ruby/issues/209#issuecomment-889064123)) by not setting the `bundler:` input and ensuring there is no `BUNDLED WITH 1.x.y` in a checked-in `Gemfile.lock`.
-* The default shell on Windows is not Bash but [PowerShell](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
+* The default shell on Windows is not Bash but [PowerShell](https://docs.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
   This can lead issues such as multi-line scripts [not working as expected](https://github.com/ruby/setup-ruby/issues/13).
 * The `PATH` contains [multiple compiler toolchains](https://github.com/ruby/setup-ruby/issues/19). Use `where.exe` to debug which tool is used.
 * For Ruby ≥ 2.4, MSYS2 is prepended to the `Path`, similar to what RubyInstaller2 does.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ jobs:
 ```
 
 See the GitHub Actions documentation for more details about the
-[workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
-and the [condition and expression syntax](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions).
+[workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+and the [condition and expression syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts).
 
 ### Supported Version Syntax
 
@@ -252,7 +252,7 @@ Note that running CI on Windows can be quite challenging if you are not very fam
 It is recommended to first get your build working on Ubuntu and macOS before trying Windows.
 
 * Use Bundler 2.2.18+ on Windows (older versions have [bugs](https://github.com/ruby/setup-ruby/issues/209#issuecomment-889064123)) by not setting the `bundler:` input and ensuring there is no `BUNDLED WITH 1.x.y` in a checked-in `Gemfile.lock`.
-* The default shell on Windows is not Bash but [PowerShell](https://docs.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
+* The default shell on Windows is not Bash but [PowerShell](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#using-a-specific-shell).
   This can lead issues such as multi-line scripts [not working as expected](https://github.com/ruby/setup-ruby/issues/13).
 * The `PATH` contains [multiple compiler toolchains](https://github.com/ruby/setup-ruby/issues/19). Use `where.exe` to debug which tool is used.
 * For Ruby ≥ 2.4, MSYS2 is prepended to the `Path`, similar to what RubyInstaller2 does.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: ['3.3', '3.4', '4.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.4' # Not needed with a .ruby-version, .tool-versions or mise.toml
+        ruby-version: '4.0' # Not needed with a .ruby-version, .tool-versions or mise.toml
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - run: bundle exec rake
 ```
@@ -98,7 +98,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec rake
 ```


### PR DESCRIPTION
## Summary
- Replace outdated `help.github.com` URLs with `docs.github.com`
- Update `ruby-version` examples from `'3.4'` to `'4.0'`
- Remove EOL Ruby versions (2.7, 3.0, 3.1, 3.2) from the matrix example

## Context
- `help.github.com` was consolidated into `docs.github.com` (existing URLs still redirect, but updating to the canonical domain for consistency)  
- Ruby 2.7 (EOL 2023-03), 3.0 (EOL 2024-04), 3.1 (EOL 2025-03), 3.2 (EOL 2026-04) are all end-of-life per https://www.ruby-lang.org/en/downloads/branches/
- Ruby 4.0 is now available as a stable release